### PR TITLE
Impl Default trait

### DIFF
--- a/src/actors.rs
+++ b/src/actors.rs
@@ -620,9 +620,9 @@ pub struct ActorSystemConfig {
     pub thread_wait_time: u16,
 }
 
-impl ActorSystemConfig {
+impl Default for ActorSystemConfig {
     /// Create the config with the default values.
-    pub fn default() -> ActorSystemConfig {
+    fn default() -> ActorSystemConfig {
         ActorSystemConfig {
             work_channel_size: 100,
             thread_pool_size: 4,


### PR DESCRIPTION
I was just trying to do this pattern:

```rust
let system = ActorSystem::create(
    ActorSystemConfig {
        thread_pool_size: num_cpus::get(),
        .. Default::default()
    }
);
```

And it didn't work to my surprise, hence this PR.  I feel a little silly since it's literally two words, but that's life.