### PR TITLE
Use `ccl::DashMap` instead of `RwLock<HashMap>`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,5 +55,5 @@ log ="^0.4"
 serde =  { version = "^1.0.97", features = ["derive", "rc"] }
 bincode = "^1.1.4"
 once_cell = "^0.2.6"
-ccl = "^5.1.1"
+ccl = "^5.1.2"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,4 +55,5 @@ log ="^0.4"
 serde =  { version = "^1.0.97", features = ["derive", "rc"] }
 bincode = "^1.1.4"
 once_cell = "^0.2.6"
+ccl = "^5.1.1"
 

--- a/src/actors.rs
+++ b/src/actors.rs
@@ -1003,15 +1003,14 @@ impl ActorSystem {
 
     /// Adds a monitor so that `monitoring` will be informed if `monitored` stops.
     pub fn monitor(&self, monitoring: &ActorId, monitored: &ActorId) {
-        let monitoring_by_monitored = &self.data.monitoring_by_monitored;
-        // NOTE: `DashMap::get_or_insert` exists but doesn't always return a mutable reference
-        // to the value it retrieves. This might change in the future versions, but for now we
-        // have to manually remove the vec from the map, update it, then reinsert
-        let (monitored, mut monitoring_vec) = monitoring_by_monitored
-            .remove(&monitored)
-            .unwrap_or_else(|| (monitored.clone(), Vec::new()));
+        let mut monitoring_by_monitored = self
+            .data
+            .monitoring_by_monitored
+            .get_raw_mut_from_key(&monitored);
+        let monitoring_vec = monitoring_by_monitored
+            .entry(monitored.clone())
+            .or_insert(Vec::new());
         monitoring_vec.push(monitoring.clone());
-        monitoring_by_monitored.insert(monitored, monitoring_vec);
     }
 }
 


### PR DESCRIPTION
Everything slotted in pretty neatly except for the `monitor` function, where I had to manually break up the get-or-insert operation due to a limitation of the `DashMap` API. I believe it is functionally equivalent though, and the tests still pass too.

And now that we don't have to manually lock the map on access, I could get rid of all the local variable aliases too if you like.