### PR TITLE
Change `MessageContent`'s visibility to private

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@
 //!   * New methods `send_new` and `try_send_new` are available to shorten boilerplate.
 //!   * Added a named system actor, `System`, that is started as the 1st actor in an `ActorSystem`.
 //!   * Added a method `system_actor_aid` to easily look up the `System` actor.
+//!   * BREAKING CHANGE: `MessageContent` was unintentionally public and is now private.
 //!
 //! [Release Notes for All Versions](https://github.com/rsimmonsjr/axiom/blob/master/RELEASE_NOTES.md)
 //!

--- a/src/message.rs
+++ b/src/message.rs
@@ -36,7 +36,7 @@ where
 }
 
 /// The message content in a message.
-pub enum MessageContent {
+enum MessageContent {
     // FIXME (Issue #66) Investigate if it is possible to get rid of the inner arc.
     /// The message is a local message.
     Local(Arc<dyn ActorMessage + 'static>),


### PR DESCRIPTION
Removing parts of the public API is technically a breaking change so I added a note on it. Could remove the message if you prefer though, as I highly doubt anyone ever tried actually using it.