### PR TITLE
Async+ Overhaul

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ matrix:
         - cargo fmt -- --check
         - cargo test
         - cargo build
-        - cargo doc
+        - cargo doc --no-deps
         - cargo package
       deploy:
         provider: cargo

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ serde_json = "^1.0.40"
 [dependencies]
 bincode = "^1.1.4"
 dashmap = "^1.0.3"
-futures-preview = { version = "0.3.0-alpha.19", features = ["async-await"] }
+futures= { version = "^0.3.1", features = ["async-await"] }
 num_cpus = "^1.10.1"
 log ="^0.4"
 once_cell = "^1.0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,9 +36,9 @@ exclude = [
 ]
 
 [badges]
-travis-ci = {repository = "rsimmonsjr/axiom" }
-is-it-maintained-issue-resolution = {repository = "rsimmonsjr/axiom" }
-is-it-maintained-open-issues  = {repository = "rsimmonsjr/axiom" }
+travis-ci = { repository = "rsimmonsjr/axiom" }
+is-it-maintained-issue-resolution = { repository = "rsimmonsjr/axiom" }
+is-it-maintained-open-issues  = { repository = "rsimmonsjr/axiom" }
 maintenance = { status = "actively-developed" }
 
 [dev-dependencies]
@@ -49,9 +49,9 @@ serde_json = "^1.0.40"
 [dependencies]
 bincode = "^1.1.4"
 dashmap = "^1.0.3"
-futures= { version = "^0.3.1", features = ["async-await"] }
+futures = "^0.3.1"
 num_cpus = "^1.10.1"
-log ="^0.4"
+log = "^0.4"
 once_cell = "^1.0.2"
 secc = "^0.0.10"
 serde = { version = "^1.0.97", features = ["derive", "rc"] }

--- a/README.md
+++ b/README.md
@@ -18,9 +18,12 @@ rather a new implementation deriving inspiration from the good parts of those pr
   * Massive internal refactor in order to support async Actors. There are very few breaking changes,
   so porting to this version will be relatively simple.
   * NOTE: Until Rust 1.39.0 hits Stable (November 7th), Axiom will require Beta Rust to compile.
-  * BREAKING CHANGE: The signature for Processors has changed from references for `Context` and `Message` to
-  values. For closures-as-actors, wrap the body in an `async` block. `move |...| {...}` becomes
-  `move |...| async { ... }`. For regular function syntax, simply add `async` in front of `fn`.
+  * BREAKING CHANGE: The signature for Processors has changed from references for `Context` and 
+  `Message` to values. For closures-as-actors, wrap the body in an `async` block. `move |...| {...}`
+  becomes `|...| async move { ... }`. For regular function syntax, simply add `async` in front of 
+  `fn`.
+  * NOTE: the positioning of `move` may need to be different, depending on semantics. Values cannot
+  be moved out of the closure and into the async block.
   * BREAKING CHANGE: Due to the nature of futures, the actor's processor cannot be given a mutable 
   reference to the state of the actor. The state needs to live at least as long as the future and 
   our research could find no way to do this easily. So now when the actor returns a status it will 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ rather a new implementation deriving inspiration from the good parts of those pr
 * 2019-11-xx 0.2.0
   * Massive internal refactor in order to support async Actors. There are very few breaking changes,
   so porting to this version will be relatively simple.
-  * NOTE: Until Rust 1.39.0 hits Stable (November 7th), Axiom will require Beta Rust to compile.
   * BREAKING CHANGE: The signature for Processors has changed from references for `Context` and 
   `Message` to values. For closures-as-actors, wrap the body in an `async` block. `move |...| {...}`
   becomes `|...| async move { ... }`. For regular function syntax, simply add `async` in front of 
@@ -35,9 +34,16 @@ rather a new implementation deriving inspiration from the good parts of those pr
           R: Future<Output = AxiomResult<S>> + Send + 'static,
           F: (FnMut(S, Context, Message) -> R) + Send + Sync + 'static  {} 
   ```
-  * The user should take note that their actor will run now when it is POLLED and not immediately 
-  as this may have some effect on the actor. Although depending on timing in actor systems is 
-  chancy at best, please be aware of this. 
+  * The user should take be aware that, at runtime, Actors will follow the semantics of Rust Futures. This means that an
+  Actor awaiting a future will not process any messages nor will continue executing until that future is ready to be 
+  polled again. While async/await will provide ergonomic usage of async APIs, this can be a concern and can affect 
+  timing.
+  * A prelude has been introduced. Attempts will be made at keeping the prelude relatively the same even across major 
+  versions, and we recommend using it whenever possible.
+  * BREAKING: Actors are now panic-tolerant! This means `assert`s and `panic`s will be caught and converted, treated the
+  same as errors. Errors should already be considered fatal, as Actors should handle any errors in their own scope.
+  * BREAKING: Error types have been broken up to be more context-specific.
+  * More `log` points have been added across the codebase.
 
 [Release Notes for All Versions](https://github.com/rsimmonsjr/axiom/blob/master/RELEASE_NOTES.md)
 

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -20,7 +20,7 @@ enum HelloMessages {
 }
 
 /// This is the handler that will be used by the actor.
-async fn hello(_: (), context: Context, message: Message) -> AxiomResult<()> {
+async fn hello(_: (), context: Context, message: Message) -> ActorResult<()> {
     if let Some(_msg) = message.content_as::<HelloMessages>() {
         println!("Hello World from Actor: {:?}", context.aid);
         context.system.trigger_shutdown();

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -12,8 +12,8 @@
 use axiom::*;
 use serde::{Deserialize, Serialize};
 
-/// The messages we will be sending to our actor. All messages must be serializeable and
-/// deserializeable with serde.
+/// The messages we will be sending to our actor. All messages must be serializable and
+/// deserializable with serde.
 #[derive(Serialize, Deserialize)]
 enum HelloMessages {
     Greet,

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -9,7 +9,7 @@
 //! * Triggering an actor system shutdown within the actor.
 //! * Awaiting the actor system to shut down.
 
-use axiom::*;
+use axiom::prelude::*;
 use serde::{Deserialize, Serialize};
 
 /// The messages we will be sending to our actor. All messages must be serializable and

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -38,5 +38,5 @@ pub fn main() {
     aid.send(Message::new(HelloMessages::Greet)).unwrap();
 
     // The actor will trigger shutdown, we just wait for it.
-    system.await_shutdown();
+    system.await_shutdown(None);
 }

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -9,9 +9,8 @@
 //! * Triggering an actor system shutdown within the actor.
 //! * Awaiting the actor system to shut down.
 
-use serde::{Deserialize, Serialize};
-
 use axiom::*;
+use serde::{Deserialize, Serialize};
 
 /// The messages we will be sending to our actor. All messages must be serializeable and
 /// deserializeable with serde.

--- a/examples/montecarlo.rs
+++ b/examples/montecarlo.rs
@@ -205,5 +205,5 @@ fn main() {
         .unwrap();
 
     // Wait for the actor system to shut down.
-    system.await_shutdown();
+    system.await_shutdown(None);
 }

--- a/examples/montecarlo.rs
+++ b/examples/montecarlo.rs
@@ -8,7 +8,7 @@
 //! * Using monitors to allow a manager actor to know when each of its child actors have completed
 //!   their work.
 
-use axiom::*;
+use axiom::prelude::*;
 use rand::{thread_rng, Rng};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;

--- a/examples/montecarlo.rs
+++ b/examples/montecarlo.rs
@@ -8,12 +8,10 @@
 //! * Using monitors to allow a manager actor to know when each of its child actors have completed
 //!   their work.
 
-use std::collections::HashMap;
-
+use axiom::*;
 use rand::{thread_rng, Rng};
 use serde::{Deserialize, Serialize};
-
-use axiom::*;
+use std::collections::HashMap;
 
 /// Represents the state of a simplified gambling game as described on the website linked above.
 #[derive(Debug, Copy, Clone)]

--- a/examples/montecarlo.rs
+++ b/examples/montecarlo.rs
@@ -38,7 +38,7 @@ impl Game {
     }
 
     /// This is the Processor function for the game actors.
-    async fn play(mut self, ctx: Context, msg: Message) -> AxiomResult<Self> {
+    async fn play(mut self, ctx: Context, msg: Message) -> ActorResult<Self> {
         // A game instance starts when the `GameManager` actor sends a message containing its `Aid`.
         // This allows this actor to send its results back to the manager once the game is complete.
         if let Some(results_aid) = msg.content_as::<Aid>() {
@@ -125,7 +125,7 @@ impl GameManager {
 
 impl GameManager {
     // This is the Processor function for the manager actor.
-    async fn gather_results(mut self, ctx: Context, msg: Message) -> AxiomResult<Self> {
+    async fn gather_results(mut self, ctx: Context, msg: Message) -> ActorResult<Self> {
         // Receive messages from the Game actors and aggregate their results in a `HashMap`.
         if let Some(game_msg) = msg.content_as::<GameMsg>() {
             self.results
@@ -161,7 +161,7 @@ impl GameManager {
                 // This code runs each time a monitored `Game` actor stops. Once all the actors are
                 // finished, the average final results of each game will be printed and then the
                 // actor system will be shut down.
-                SystemMsg::Stopped(_) => {
+                SystemMsg::Stopped { .. } => {
                     self.games_finished += 1;
                     if self.games_finished == self.total_games {
                         // Each vec of results contains the entire history of a game for every time that

--- a/examples/philosophers.rs
+++ b/examples/philosophers.rs
@@ -20,15 +20,13 @@
 //! panics ensue. Some FSM implementations might be quite a bit more lose, preferring to ignore
 //! badly timeds messages. This is largely up to the user.
 
+use axiom::*;
 use std::collections::HashMap;
 use std::env;
 use std::time::{Duration, Instant};
-
 use log::LevelFilter;
 use log::{error, info};
 use serde::{Deserialize, Serialize};
-
-use axiom::*;
 
 /// A command sent to a fork actor.
 #[derive(Debug, Serialize, Deserialize)]

--- a/examples/philosophers.rs
+++ b/examples/philosophers.rs
@@ -20,7 +20,7 @@
 //! panics ensue. Some FSM implementations might be quite a bit more lose, preferring to ignore
 //! badly timed messages. This is largely up to the user.
 
-use axiom::*;
+use axiom::prelude::*;
 use log::LevelFilter;
 use log::{error, info};
 use serde::{Deserialize, Serialize};

--- a/examples/philosophers.rs
+++ b/examples/philosophers.rs
@@ -246,7 +246,7 @@ impl Philosopher {
     }
 
     /// Changes the philosopher to a state of eating.
-    fn begin_eating(&mut self, context: Context) -> Result<(), AxiomError> {
+    fn begin_eating(&mut self, context: Context) -> Result<(), Box<StdError>> {
         self.metrics.time_hungry += Instant::elapsed(&self.last_state_change);
         self.last_state_change = Instant::now();
         self.state = PhilosopherState::Eating;
@@ -285,7 +285,7 @@ impl Philosopher {
     }
 
     /// Helper to request forks that the philosopher doesnt have.
-    fn request_missing_forks(&mut self, context: Context) -> Result<(), AxiomError> {
+    fn request_missing_forks(&mut self, context: Context) -> Result<(), Box<StdError>> {
         if !self.has_left_fork && !self.left_fork_requested {
             self.left_fork_requested = true;
             self.left_fork_aid
@@ -330,7 +330,7 @@ impl Philosopher {
 
     /// Changes the philosopher to the state of thinking. Note that this doesn't mean that the
     /// philosopher will put down his forks. He will only do that if requested to.
-    fn begin_thinking(&mut self, context: Context) -> Result<(), AxiomError> {
+    fn begin_thinking(&mut self, context: Context) -> Result<(), Box<StdError>> {
         self.state = PhilosopherState::Thinking;
         self.metrics.state_change_count += 1;
         self.metrics.time_eating += Instant::elapsed(&self.last_state_change);

--- a/examples/philosophers.rs
+++ b/examples/philosophers.rs
@@ -16,9 +16,9 @@
 //!   * Ability to use a struct, `MetricsReply` and `EndSimulation` as a message.
 //!   * Use of `enum` as well as `struct` values for messages.
 //!  
-//! This example is extremely strict. If the FSM at any time gets out of synch with expectations
+//! This example is extremely strict. If the FSM at any time gets out of sync with expectations
 //! panics ensue. Some FSM implementations might be quite a bit more lose, preferring to ignore
-//! badly timeds messages. This is largely up to the user.
+//! badly timed messages. This is largely up to the user.
 
 use axiom::*;
 use log::LevelFilter;
@@ -246,7 +246,7 @@ impl Philosopher {
     }
 
     /// Changes the philosopher to a state of eating.
-    fn begin_eating(&mut self, context: Context) -> Result<(), Box<StdError>> {
+    fn begin_eating(&mut self, context: Context) -> Result<(), StdError> {
         self.metrics.time_hungry += Instant::elapsed(&self.last_state_change);
         self.last_state_change = Instant::now();
         self.state = PhilosopherState::Eating;
@@ -285,7 +285,7 @@ impl Philosopher {
     }
 
     /// Helper to request forks that the philosopher doesnt have.
-    fn request_missing_forks(&mut self, context: Context) -> Result<(), Box<StdError>> {
+    fn request_missing_forks(&mut self, context: Context) -> Result<(), StdError> {
         if !self.has_left_fork && !self.left_fork_requested {
             self.left_fork_requested = true;
             self.left_fork_aid
@@ -330,7 +330,7 @@ impl Philosopher {
 
     /// Changes the philosopher to the state of thinking. Note that this doesn't mean that the
     /// philosopher will put down his forks. He will only do that if requested to.
-    fn begin_thinking(&mut self, context: Context) -> Result<(), Box<StdError>> {
+    fn begin_thinking(&mut self, context: Context) -> Result<(), StdError> {
         self.state = PhilosopherState::Thinking;
         self.metrics.state_change_count += 1;
         self.metrics.time_eating += Instant::elapsed(&self.last_state_change);

--- a/examples/philosophers.rs
+++ b/examples/philosophers.rs
@@ -21,12 +21,12 @@
 //! badly timeds messages. This is largely up to the user.
 
 use axiom::*;
-use std::collections::HashMap;
-use std::env;
-use std::time::{Duration, Instant};
 use log::LevelFilter;
 use log::{error, info};
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::env;
+use std::time::{Duration, Instant};
 
 /// A command sent to a fork actor.
 #[derive(Debug, Serialize, Deserialize)]

--- a/examples/philosophers.rs
+++ b/examples/philosophers.rs
@@ -540,5 +540,5 @@ pub fn main() {
         )
         .expect("failed to create shutdown actor");
 
-    system.await_shutdown();
+    system.await_shutdown(None);
 }

--- a/src/actors.rs
+++ b/src/actors.rs
@@ -6,10 +6,8 @@
 //! created by calling `system::spawn().with()` with any kind of function or closure that
 //! implements the `Processor` trait.
 
-use crate::message::*;
-use crate::system::*;
-use crate::Panic;
-use crate::*;
+use crate::message::ActorMessage;
+use crate::prelude::*;
 use futures::{FutureExt, Stream};
 use log::{debug, error, warn};
 use secc::*;

--- a/src/actors.rs
+++ b/src/actors.rs
@@ -318,7 +318,7 @@ impl Aid {
     ///     )
     ///     .unwrap();
     ///
-    /// let arc = Arc::new(11);
+    /// let arc = Arc::new(11 as i32);
     /// match aid.send_arc(arc.clone()) {
     ///     Ok(_) => println!("OK Then!"),
     ///     Err(e) => println!("Ooops {:?}", e),

--- a/src/actors.rs
+++ b/src/actors.rs
@@ -975,8 +975,8 @@ mod tests {
             .unwrap();
 
         match aid.send(Message::new(11)) {
-            Ok(_) => println!("OK Then!"),
-            Err(e) => println!("Ooops {:?}", e),
+            Ok(_) => info!("OK Then!"),
+            Err(e) => info!("Ooops {:?}", e),
         }
 
         system.await_shutdown(None);

--- a/src/actors.rs
+++ b/src/actors.rs
@@ -913,7 +913,7 @@ impl ActorStream {
 
     fn overwrite_on_stop(&self, result: Result<Status, StdError>) -> Result<Status, StdError> {
         match self.stopping {
-            true => Ok(Status::Stop),
+            true => result.map(|_| Ok(Status::Stop)),
             false => result,
         }
     }

--- a/src/actors.rs
+++ b/src/actors.rs
@@ -1189,14 +1189,10 @@ mod tests {
                     } else if let Some(msg) = message.content_as::<SystemMsg>() {
                         match &*msg {
                             SystemMsg::Start => Ok((t, Status::Done)),
-                            m => {
-                                t.panic(format!("unexpected message: {:?}", m));
-                                Ok((t, Status::Stop))
-                            }
+                            m => t.panic(format!("unexpected message: {:?}", m)),
                         }
                     } else {
-                        t.panic("Unknown Message received");
-                        Ok((t, Status::Stop))
+                        t.panic("Unknown Message received")
                     }
                 }
             })
@@ -1240,14 +1236,10 @@ mod tests {
                         match &*msg {
                             SystemMsg::Start => Ok((t, Status::Done)),
                             SystemMsg::Stop => Ok((t, Status::Done)),
-                            m => {
-                                t.panic(format!("unexpected message: {:?}", m));
-                                Ok((t, Status::Stop))
-                            }
+                            m => t.panic(format!("unexpected message: {:?}", m)),
                         }
                     } else {
-                        t.panic("Unknown Message received");
-                        Ok((t, Status::Stop))
+                        t.panic("Unknown Message received")
                     }
                 }
             })

--- a/src/actors.rs
+++ b/src/actors.rs
@@ -913,7 +913,7 @@ impl ActorStream {
 
     fn overwrite_on_stop(&self, result: Result<Status, StdError>) -> Result<Status, StdError> {
         match self.stopping {
-            true => result.map(|_| Ok(Status::Stop)),
+            true => result.map(|_| Status::Stop),
             false => result,
         }
     }

--- a/src/actors.rs
+++ b/src/actors.rs
@@ -1215,7 +1215,7 @@ mod tests {
             } else if max < Instant::elapsed(&start) {
                 panic!("Timed out waiting for actor to stop!");
             }
-            thread::sleep(Duration::from_millis(1));
+            sleep(1);
         }
 
         system.trigger_and_await_shutdown(None);
@@ -1266,7 +1266,7 @@ mod tests {
             } else if max < Instant::elapsed(&start) {
                 panic!("Timed out waiting for actor to stop!");
             }
-            thread::sleep(Duration::from_millis(1));
+            sleep(1);
         }
         system.trigger_and_await_shutdown(None);
         tracker.collect();

--- a/src/actors.rs
+++ b/src/actors.rs
@@ -862,7 +862,9 @@ impl ActorStream {
                     "[{}] returned an error when processing: {}",
                     self.context.aid, &e
                 );
-                self.context.system.internal_stop_actor(&self.context.aid, e);
+                self.context
+                    .system
+                    .internal_stop_actor(&self.context.aid, e);
             }
         }
     }

--- a/src/actors.rs
+++ b/src/actors.rs
@@ -235,7 +235,7 @@ impl Aid {
     ///
     /// # Examples
     /// ```
-    /// use axiom::*;
+    /// use axiom::prelude::*;
     /// use std::sync::Arc;
     /// use std::time::Duration;
     ///
@@ -302,7 +302,7 @@ impl Aid {
     /// The `Arc` sent will be transferred to the ownership of the `Aid`.
     ///
     /// ```
-    /// use axiom::*;
+    /// use axiom::prelude::*;
     /// use std::sync::Arc;
     /// use std::time::Duration;
     ///
@@ -343,7 +343,7 @@ impl Aid {
     /// If the code wishes to resend a message it should just call just call `send(msg)`.
     ///
     /// ```
-    /// use axiom::*;
+    /// use axiom::prelude::*;
     /// use std::sync::Arc;
     /// use std::time::Duration;
     ///
@@ -386,7 +386,7 @@ impl Aid {
     ///
     /// # Examples
     /// ```
-    /// use axiom::*;
+    /// use axiom::prelude::*;
     /// use std::sync::Arc;
     /// use std::time::Duration;
     ///
@@ -445,7 +445,7 @@ impl Aid {
     ///
     /// # Examples
     /// ```
-    /// use axiom::*;
+    /// use axiom::prelude::*;
     /// use std::sync::Arc;
     /// use std::time::Duration;
     ///
@@ -487,7 +487,7 @@ impl Aid {
     ///
     /// # Examples
     /// ```
-    /// use axiom::*;
+    /// use axiom::prelude::*;
     /// use std::sync::Arc;
     /// use std::time::Duration;
     ///
@@ -947,7 +947,7 @@ fn inner_poll(
         Err(e) => {
             warn!("Actor panicked! Catching as error");
             Poll::Ready(Err(Panic::from(e).into()))
-        },
+        }
     }
 }
 

--- a/src/actors.rs
+++ b/src/actors.rs
@@ -256,7 +256,7 @@ impl Aid {
     ///     Err(e) => println!("Ooops {:?}", e),
     /// }
     ///
-    /// system.await_shutdown();
+    /// system.await_shutdown(None);
     /// ```
     pub fn send(&self, message: Message) -> Result<(), AxiomError> {
         match &self.data.sender {
@@ -324,7 +324,7 @@ impl Aid {
     ///     Err(e) => println!("Ooops {:?}", e),
     /// }
     ///
-    /// system.await_shutdown();
+    /// system.await_shutdown(None);
     /// ```
     pub fn send_arc<T>(&self, value: Arc<T>) -> Result<(), AxiomError>
     where
@@ -364,7 +364,7 @@ impl Aid {
     ///     Err(e) => println!("Ooops {:?}", e),
     /// }
     ///
-    /// system.await_shutdown();
+    /// system.await_shutdown(None);
     /// ```
     pub fn send_new<T>(&self, value: T) -> Result<(), AxiomError>
     where
@@ -407,7 +407,7 @@ impl Aid {
     ///     Err(e) => println!("Ooops {:?}", e),
     /// }
     ///
-    /// system.await_shutdown();
+    /// system.await_shutdown(None);
     /// ```
     pub fn send_after(&self, message: Message, duration: Duration) -> Result<(), AxiomError> {
         match &self.data.sender {
@@ -467,7 +467,7 @@ impl Aid {
     ///     Err(e) => println!("Ooops {:?}", e),
     /// }
     ///
-    /// system.await_shutdown();
+    /// system.await_shutdown(None);
     /// ```
     pub fn send_arc_after<T>(&self, value: Arc<T>, duration: Duration) -> Result<(), AxiomError>
     where
@@ -508,7 +508,7 @@ impl Aid {
     ///     Err(e) => println!("Ooops {:?}", e),
     /// }
     ///
-    /// system.await_shutdown();
+    /// system.await_shutdown(None);
     /// ```
     pub fn send_new_after<T>(&self, value: T, duration: Duration) -> Result<(), AxiomError>
     where
@@ -938,7 +938,7 @@ mod tests {
             Err(e) => println!("Ooops {:?}", e),
         }
 
-        system.await_shutdown();
+        system.await_shutdown(None);
     }
 
     /// Tests that unserializable messages can be sent locally.
@@ -972,7 +972,7 @@ mod tests {
         aid.send(Message::new(Foo {})).unwrap();
         await_received(&aid, 2, 1000).unwrap();
 
-        system.await_shutdown_with_timeout(Duration::from_millis(1000));
+        system.await_shutdown(Duration::from_millis(1000));
     }
 
     /// This test verifies that an actor's functions that retrieve basic info are working for
@@ -990,7 +990,7 @@ mod tests {
         assert_eq!(None, aid.data.name);
         assert_eq!(aid.data.name, aid.name());
 
-        system.trigger_and_await_shutdown();
+        system.trigger_and_await_shutdown(None);
     }
 
     /// This test verifies that an actor's functions that retrieve basic info are working for
@@ -1008,7 +1008,7 @@ mod tests {
         assert_eq!(Some("A".to_string()), aid.data.name);
         assert_eq!(aid.data.name, aid.name());
 
-        system.trigger_and_await_shutdown();
+        system.trigger_and_await_shutdown(None);
     }
 
     /// Tests serialization and deserialization of `Aid`s. This verifies that deserialized
@@ -1107,7 +1107,7 @@ mod tests {
 
         // Wait for the Start and our message to get there because test is asynchronous.
         await_received(&aid, 2, 1000).unwrap();
-        system.trigger_and_await_shutdown();
+        system.trigger_and_await_shutdown(None);
     }
 
     /// Tests that messages cannot be sent to an `aid` for an actor that has been stopped.
@@ -1166,7 +1166,7 @@ mod tests {
             thread::sleep(Duration::from_millis(1));
         }
 
-        system.trigger_and_await_shutdown();
+        system.trigger_and_await_shutdown(None);
     }
 
     /// Tests that an actor cannot override the processing of a `Stop` message by returning a
@@ -1210,6 +1210,6 @@ mod tests {
             thread::sleep(Duration::from_millis(1));
         }
 
-        system.trigger_and_await_shutdown();
+        system.trigger_and_await_shutdown(None);
     }
 }

--- a/src/actors.rs
+++ b/src/actors.rs
@@ -962,23 +962,20 @@ mod tests {
 
         let aid = system
             .spawn()
-            .with(
-                0 as usize,
-                move |_state: &mut usize, context: &Context, message: &Message| {
+            .with((), move |_state: (), context: Context, message: Message| {
+                async move {
                     if let Some(_) = message.content_as::<Foo>() {
                         context.system.trigger_shutdown();
                     }
-                    Ok(Status::Done)
-                },
-            )
+                    Ok(((), Status::Done))
+                }
+            })
             .unwrap();
 
         aid.send(Message::new(Foo {})).unwrap();
         await_received(&aid, 2, 1000).unwrap();
 
-        system
-            .await_shutdown_with_timeout(Duration::from_millis(1000))
-            .unwrap();
+        system.await_shutdown_with_timeout(Duration::from_millis(1000));
     }
 
     /// This test verifies that an actor's functions that retrieve basic info are working for

--- a/src/actors.rs
+++ b/src/actors.rs
@@ -9,7 +9,7 @@
 use crate::message::ActorMessage;
 use crate::prelude::*;
 use futures::{FutureExt, Stream};
-use log::{debug, error, warn};
+use log::{debug, error, trace, warn};
 use secc::*;
 use serde::de::Deserializer;
 use serde::ser::Serializer;

--- a/src/actors.rs
+++ b/src/actors.rs
@@ -950,11 +950,11 @@ fn inner_poll(
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use crate::tests::*;
+    use log::*;
     use std::thread;
     use std::time::Instant;
-    use crate::tests::*;
-    use super::*;
-    use log::*;
 
     /// This is identical to the documentation but here so that its formatted by rust and we can
     /// copy paste this into the docs. It's also easier to debug here.
@@ -1269,7 +1269,6 @@ mod tests {
             thread::sleep(Duration::from_millis(1));
         }
         system.trigger_and_await_shutdown(None);
-        info!("Collecting potential panics from");
         tracker.collect();
     }
 }

--- a/src/actors.rs
+++ b/src/actors.rs
@@ -6,6 +6,16 @@
 //! created by calling `system::spawn().with()` with any kind of function or closure that
 //! implements the `Processor` trait.
 
+use crate::message::*;
+use crate::system::*;
+use crate::*;
+use futures::{FutureExt, Stream};
+use log::error;
+use secc::*;
+use serde::de::Deserializer;
+use serde::ser::Serializer;
+use serde::{Deserialize, Serialize};
+use std::cell::UnsafeCell;
 use std::future::Future;
 use std::hash::{Hash, Hasher};
 use std::marker::{Send, Sync};
@@ -15,19 +25,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::task::Poll;
 use std::time::Duration;
-
-use futures::{FutureExt, Stream};
-use log::error;
-use secc::*;
-use serde::de::Deserializer;
-use serde::ser::Serializer;
-use serde::{Deserialize, Serialize};
 use uuid::Uuid;
-
-use crate::message::*;
-use crate::system::*;
-use crate::*;
-use std::cell::UnsafeCell;
 
 /// Status of the message and potentially the actor as a resulting from processing a message
 /// with the actor.

--- a/src/actors.rs
+++ b/src/actors.rs
@@ -11,7 +11,7 @@ use crate::system::*;
 use crate::Panic;
 use crate::*;
 use futures::{FutureExt, Stream};
-use log::{debug, error};
+use log::{debug, error, warn};
 use secc::*;
 use serde::de::Deserializer;
 use serde::ser::Serializer;
@@ -944,7 +944,10 @@ fn inner_poll(
 ) -> Poll<Result<Status, StdError>> {
     match catch_unwind(AssertUnwindSafe(|| future.as_mut().poll(cx))) {
         Ok(p) => p,
-        Err(e) => Poll::Ready(Err(Panic::from(e).into())),
+        Err(e) => {
+            warn!("Actor panicked! Catching as error");
+            Poll::Ready(Err(Panic::from(e).into()))
+        },
     }
 }
 

--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -8,6 +8,7 @@
 //! for a reference. It is designed to be the default way Axiom is clustered and thus it will be
 //! robust and well tested like the rest of Axiom.
 
+use crate::prelude::*;
 use log::{error, info};
 use secc::*;
 use std::collections::HashMap;
@@ -21,8 +22,6 @@ use std::thread;
 use std::thread::JoinHandle;
 use std::time::Duration;
 use uuid::Uuid;
-
-use crate::prelude::*;
 
 /// Encapsulates information on a connection to another actor system.
 struct ConnectionData {

--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -22,7 +22,7 @@ use std::thread::JoinHandle;
 use std::time::Duration;
 use uuid::Uuid;
 
-use crate::*;
+use crate::prelude::*;
 
 /// Encapsulates information on a connection to another actor system.
 struct ConnectionData {

--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -8,6 +8,8 @@
 //! for a reference. It is designed to be the default way Axiom is clustered and thus it will be
 //! robust and well tested like the rest of Axiom.
 
+use log::{error, info};
+use secc::*;
 use std::collections::HashMap;
 use std::io::prelude::*;
 use std::io::{BufReader, BufWriter};
@@ -18,9 +20,6 @@ use std::sync::{Condvar, Mutex};
 use std::thread;
 use std::thread::JoinHandle;
 use std::time::Duration;
-
-use log::{error, info};
-use secc::*;
 use uuid::Uuid;
 
 use crate::*;

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -490,7 +490,7 @@ mod tests {
                 .len();
             assert_eq!(pending, 1, "Actor should be pending");
         }
-        sleep(25);
+        sleep(30);
         {
             let pending = system
                 .executor()

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -242,6 +242,7 @@ impl AxiomReactor {
                     // Still pending, return to wait_queue. Drop the wakeup, because the futures
                     // will re-add it later through their wakers.
                     Poll::Pending => {
+                        trace!("Reactor-{} waiting on pending Actor", self.name);
                         self.wait(task);
                         break;
                     }
@@ -293,6 +294,11 @@ impl AxiomReactor {
             .write()
             .expect("Poisoned run_queue")
             .push_back(wakeup);
+        self.thread_condvar
+            .read()
+            .expect("Poisoned Reactor condvar")
+            .1
+            .notify_one();
     }
 
     /// Pop the next Wakeup.

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -469,8 +469,8 @@ mod tests {
                 }
             })
             .unwrap();
-        sleep(1);
-        assert_eq!(
+        sleep(5);    // Apparently we can't count on SystemMsg::Start being processed and the Task
+        assert_eq!(  // returned to the executor in less than 1ms. Failed once in 1000 iterations.
             system.executor().sleeping.len(),
             2,
             "Either the SystemActor or test Actor are not sleeping"

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -188,10 +188,11 @@ pub enum ShutdownResult {
     Panicked,
 }
 
-/// The Reactor is a single-threaded loop that will poll the woken Actors. It will run scheduling
-/// checks for `Ready(Some)`, either re-running or returning to the Executor for schedule
-/// adjustments. It will return the Task to the Executor on `Ready(None)`, until the Actor wakes
-/// again. It will return the Task to the wait_queue on `Pending`.
+/// The Reactor is a wrapper for a worker thread. It contains the queues, locks, and other state
+/// information necessary to manage the work load and worker thread.
+///
+/// Actors are added to the Reactor on waking, queued for polling. If they can be polled again, they
+/// are retained till they are depleted of messages or are stopped.
 #[derive(Clone)]
 pub(crate) struct AxiomReactor {
     /// The ID of the Reactor

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -58,6 +58,7 @@ impl AxiomExecutor {
             self.thread_pool
                 .spawn(format!("ActorReactor-{}", reactor.name), move || {
                     sys.init_current();
+                    futures::executor::enter().expect("Executor nested in other executor");
                     loop {
                         if !reactor.thread() {
                             break;

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -453,6 +453,19 @@ mod tests {
     }
 
     #[test]
+    fn test_thread_wakes_after_no_work() {
+        init_test_log();
+
+        let system = ActorSystem::create(ActorSystemConfig::default().thread_pool_size(1));
+        let aid = system.spawn().with((), simple_handler).unwrap();
+        // Sleep for a little longer than the condvar's default timeout
+        sleep(125);
+        aid.send_new(11);
+        await_received(&aid, 2, 1000).unwrap();
+        system.trigger_and_await_shutdown(None);
+    }
+
+    #[test]
     fn test_actor_awake_phases() {
         init_test_log();
 

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -1,7 +1,7 @@
 //! The Executor is responsible for the high-level scheduling of Actors.
 
 use crate::actors::ActorStream;
-use crate::{ActorSystem, AxiomError, Status};
+use crate::{ActorSystem, Status, StdError};
 use dashmap::DashMap;
 use futures::task::ArcWake;
 use futures::Stream;
@@ -475,7 +475,7 @@ struct Task {
 }
 
 impl Task {
-    fn poll(&mut self, waker: &Waker) -> Poll<Option<Result<Status, AxiomError>>> {
+    fn poll(&mut self, waker: &Waker) -> Poll<Option<Result<Status, Box<StdError>>>> {
         let mut ctx = Context::from_waker(waker);
 
         self.actor

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -2,7 +2,7 @@
 
 use crate::actors::ActorStream;
 use crate::executor::thread_pool::AxiomThreadPool;
-use crate::{ActorSystem, Aid, Status, StdError};
+use crate::prelude::*;
 use dashmap::DashMap;
 use futures::task::ArcWake;
 use futures::Stream;

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -469,8 +469,10 @@ mod tests {
                 }
             })
             .unwrap();
-        sleep(5);    // Apparently we can't count on SystemMsg::Start being processed and the Task
-        assert_eq!(  // returned to the executor in less than 1ms. Failed once in 1000 iterations.
+        // Apparently we can't count on SystemMsg::Start being processed and the Task returned to
+        // the executor in less than 1ms. Set as such, it failed once in 1000 iterations.
+        sleep(5);
+        assert_eq!(
             system.executor().sleeping.len(),
             2,
             "Either the SystemActor or test Actor are not sleeping"

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -460,7 +460,7 @@ mod tests {
         let aid = system.spawn().with((), simple_handler).unwrap();
         // Sleep for a little longer than the condvar's default timeout
         sleep(125);
-        aid.send_new(11);
+        let _ = aid.send_new(11);
         await_received(&aid, 2, 1000).unwrap();
         system.trigger_and_await_shutdown(None);
     }
@@ -490,7 +490,7 @@ mod tests {
             2,
             "Either the SystemActor or test Actor are not sleeping"
         );
-        aid.send_new(()).unwrap();
+        let _ = aid.send_new(()).unwrap();
         sleep(5);
         {
             let pending = system

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -216,20 +216,15 @@ impl AxiomReactor {
                             self.executor.return_task(task, self.id);
                             break;
                         }
-                        let result = result.unwrap();
-                        let is_stopping = match &result {
-                            Ok(Status::Stop) | Err(_) => true,
-                            _ => false,
-                        };
                         // The Actor should handle its own internal modifications in response to the
                         // result.
-                        {
+                        let is_stopping = {
                             task.actor
                                 .lock()
                                 .expect("Poisoned Actor")
-                                .handle_result(result);
-                        }
-                        // Intentional or error'd stop means drop. It's dead, Jim.
+                                .handle_result(result.unwrap())
+                        };
+                        // It's dead, Jim.
                         if is_stopping {
                             break;
                         }

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -1,3 +1,11 @@
+//! The Executor is responsible for the high-level scheduling of Actors.
+
+use crate::actors::PinnedActorRef;
+use crate::{ActorSystemConfig, AxiomError, Status};
+use dashmap::DashMap;
+use futures::task::ArcWake;
+use futures::Stream;
+use log::debug;
 use std::collections::{BTreeMap, VecDeque};
 use std::sync::atomic::{AtomicBool, AtomicU16, Ordering};
 use std::sync::{Arc, Condvar, Mutex, RwLock};
@@ -5,18 +13,10 @@ use std::task::{Context, Poll, Waker};
 use std::thread;
 use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
-
-use dashmap::DashMap;
-use futures::task::ArcWake;
-use futures::Stream;
-use log::debug;
 use uuid::Uuid;
 
-use crate::actors::PinnedActorRef;
-use crate::{ActorSystemConfig, AxiomError, Status};
-
-/// The Executor is responsible for the starting and high-level scheduling of Actors. When an
-/// Actor is registered, it is wrapped in a Task and added to the sleep queue. When the Actor is
+/// The Executor is responsible for the high-level scheduling of Actors. When an Actor is
+/// registered, it is wrapped in a Task and added to the sleep queue. When the Actor is
 /// woken by a sent message, the Executor will check its scheduling data and queue it in the
 /// appropriate Reactor.
 #[derive(Clone)]

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -1,6 +1,7 @@
 //! The Executor is responsible for the high-level scheduling of Actors.
 
 use crate::actors::ActorStream;
+use crate::executor::thread_pool::AxiomThreadPool;
 use crate::{ActorSystem, Aid, Status, StdError};
 use dashmap::DashMap;
 use futures::task::ArcWake;
@@ -11,7 +12,6 @@ use std::pin::Pin;
 use std::sync::{Arc, Condvar, Mutex, RwLock};
 use std::task::{Context, Poll, Waker};
 use std::time::{Duration, Instant};
-use crate::executor::thread_pool::AxiomThreadPool;
 
 mod thread_pool;
 
@@ -54,7 +54,10 @@ impl AxiomExecutor {
             let reactor = AxiomReactor::new(self.clone(), system.clone(), i);
             self.reactors.insert(i, reactor.clone());
             self.actors_per_reactor.insert(i, 0);
-            self.thread_pool.spawn(format!("ActorReactor-{}", reactor.name), move ||reactor.thread());
+            self.thread_pool
+                .spawn(format!("ActorReactor-{}", reactor.name), move || {
+                    reactor.thread()
+                });
         }
     }
 

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -449,6 +449,8 @@ impl AxiomReactor {
     /// locks so it can release them all at once. Additionally, informs the ActorSystem of the Actor
     /// that poisoned it.
     fn recover_from_panic(&self) {
+        self.executor.shutdown_semaphore.decrement();
+
         let _run_queue_guard = match self.run_queue.write() {
             Ok(g) => g,
             Err(psn) => psn.into_inner(),

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -158,8 +158,6 @@ pub(crate) struct AxiomReactor {
     thread_wait_time: Duration,
     /// How long to work on an Actor before moving on to the next Wakeup.
     time_slice: Duration,
-    /// The current Actor being processed by the Reactor.
-    current_actor: Arc<Mutex<Option<Aid>>>,
 }
 
 // A little hack to dictate a loop from inside a function call.
@@ -182,7 +180,6 @@ impl AxiomReactor {
             thread_condvar: Arc::new(RwLock::new((Mutex::new(()), Condvar::new()))),
             thread_wait_time: system.config().thread_wait_time,
             time_slice: system.config().time_slice,
-            current_actor: Arc::new(Mutex::new(None)),
         }
     }
 
@@ -277,9 +274,6 @@ impl AxiomReactor {
         if let Some(w) = self.get_woken() {
             if let Some(task) = self.remove_waiting(&w.id) {
                 trace!("Reactor-{} received Wakeup", self.name);
-                {
-                    *self.current_actor.lock().expect("Poisoned current_actor") = Some(w.id.clone())
-                }
                 LoopResult::Ok((w, task))
             } else {
                 trace!("Reactor-{} dropping futile WakeUp", self.name);

--- a/src/executor/thread_pool.rs
+++ b/src/executor/thread_pool.rs
@@ -16,13 +16,14 @@ impl AxiomThreadPool {
             state: Mutex::new(ThreadState::Stopped),
             drain: self.drain.clone(),
         });
-
         self.thread(f, deed.clone());
-
         deed
     }
 
-    fn thread<F: FnMut() + Send + 'static>(&self, mut f: F, deed: Arc<ThreadDeed>) {
+    fn thread<F>(&self, mut f: F, deed: Arc<ThreadDeed>)
+    where
+        F: FnMut() + Send + 'static,
+    {
         thread::Builder::new()
             .name(deed.name.clone())
             .spawn(move || {

--- a/src/executor/thread_pool.rs
+++ b/src/executor/thread_pool.rs
@@ -1,0 +1,161 @@
+use crate::executor::ShutdownResult;
+use log::{debug, error, trace};
+use std::sync::{Arc, Condvar, Mutex};
+use std::thread;
+use std::time::Duration;
+
+#[derive(Default)]
+pub(crate) struct AxiomThreadPool {
+    drain: Arc<DrainAwait>,
+}
+
+impl AxiomThreadPool {
+    pub fn spawn<F: FnMut() + Send + 'static>(&self, name: String, f: F) -> Arc<ThreadDeed> {
+        let deed = Arc::new(ThreadDeed {
+            name,
+            state: Mutex::new(ThreadState::Stopped),
+            drain: self.drain.clone(),
+        });
+
+        self.thread(f, deed.clone());
+
+        deed
+    }
+
+    fn thread<F: FnMut() + Send + 'static>(&self, mut f: F, deed: Arc<ThreadDeed>) {
+        thread::Builder::new()
+            .name(deed.name.clone())
+            .spawn(move || {
+                let lease = ThreadLease::new(deed);
+                lease.deed.drain.increment();
+                debug!("Thread {} has started", lease.deed.name);
+                lease.deed.set_running();
+                f();
+                lease.deed.set_stopped();
+            })
+            .expect("Failed to spawn thread");
+    }
+
+    pub fn await_shutdown(&self, timeout: impl Into<Option<Duration>>) -> ShutdownResult {
+        match timeout.into() {
+            Some(t) => self.drain.wait_timeout(t),
+            None => self.drain.wait(),
+        }
+    }
+}
+
+pub(crate) struct ThreadDeed {
+    pub name: String,
+    pub state: Mutex<ThreadState>,
+    drain: Arc<DrainAwait>,
+}
+
+impl ThreadDeed {
+    fn set_running(&self) {
+        *self.state.lock().unwrap() = ThreadState::Running;
+    }
+
+    fn set_stopped(&self) {
+        *self.state.lock().unwrap() = ThreadState::Stopped;
+    }
+}
+
+struct ThreadLease {
+    deed: Arc<ThreadDeed>,
+}
+
+impl ThreadLease {
+    pub fn new(deed: Arc<ThreadDeed>) -> Self {
+        Self { deed }
+    }
+}
+
+impl Drop for ThreadLease {
+    fn drop(&mut self) {
+        let mut g = match self.deed.state.lock() {
+            Ok(g) => g,
+            Err(psn) => psn.into_inner(),
+        };
+        // If the Lease dropped while Running, it Panicked.
+        if let ThreadState::Running = *g {
+            *g = ThreadState::Panicked;
+            error!("Thread {} panicked!", self.deed.name)
+        } else {
+            debug!("Thread {} has stopped", self.deed.name)
+        }
+        self.deed.drain.decrement();
+    }
+}
+
+pub enum ThreadState {
+    Running,
+    Stopped,
+    Panicked,
+}
+
+/// A semaphore of sorts that unblocks when its internal counter hits 0
+#[derive(Default)]
+struct DrainAwait {
+    /// Mutex for blocking on
+    mutex: Mutex<u16>,
+    /// Condvar for waiting on
+    condvar: Condvar,
+}
+
+impl DrainAwait {
+    /// Increment the counter
+    pub fn increment(&self) {
+        let mut g = self.mutex.lock().expect("DrainAwait poisoned");
+        let new = *g + 1;
+        trace!("Incrementing DrainAwait to {}", new);
+        *g += 1;
+    }
+
+    /// Decrement the counter, notify condvar if it hits 0
+    pub fn decrement(&self) {
+        let mut guard = self.mutex.lock().expect("DrainAwait poisoned");
+        *guard -= 1;
+        trace!("Decrementing DrainAwait to {}", *guard);
+        if *guard == 0 {
+            debug!("Notifying blocked threads");
+            self.condvar.notify_all();
+        }
+    }
+
+    /// Block on the condvar
+    pub fn wait(&self) -> ShutdownResult {
+        let mut guard = match self.mutex.lock() {
+            Ok(g) => g,
+            Err(_) => return ShutdownResult::Panicked,
+        };
+
+        while *guard != 0 {
+            guard = match self.condvar.wait(guard) {
+                Ok(g) => g,
+                Err(_) => return ShutdownResult::Panicked,
+            };
+        }
+        ShutdownResult::Ok
+    }
+
+    /// Block on the condvar until it times out
+    pub fn wait_timeout(&self, timeout: Duration) -> ShutdownResult {
+        let mut guard = match self.mutex.lock() {
+            Ok(g) => g,
+            Err(_) => return ShutdownResult::Panicked,
+        };
+
+        while *guard != 0 {
+            let (new_guard, timeout) = match self.condvar.wait_timeout(guard, timeout) {
+                Ok(ret) => (ret.0, ret.1),
+                Err(_) => return ShutdownResult::Panicked,
+            };
+
+            if timeout.timed_out() {
+                return ShutdownResult::TimedOut;
+            }
+            guard = new_guard;
+        }
+        ShutdownResult::Ok
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -353,6 +353,10 @@ mod tests {
             .try_init();
     }
 
+    pub fn sleep(millis: u64) {
+        thread::sleep(Duration::from_millis(millis))
+    }
+
     /// A function that just returns `Ok(Status::Done)` which can be used as a handler for
     /// a simple dummy actor.
     pub async fn simple_handler(_: (), _: Context, _: Message) -> ActorResult<()> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -265,17 +265,14 @@ impl std::fmt::Display for AidError {
     }
 }
 
-impl std::error::Error for AidError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        None
-    }
-}
+impl std::error::Error for AidError { }
 
-pub type StdError = dyn Error + Send + Sync + 'static;
+/// A helper alias to ensure returned errors conform as needed.
+pub type StdError = Box<dyn Error + Send + Sync + 'static>;
 
 /// A type for a result from an actor's message processor.
 /// A Result::Err is treated as a fatal error, and the Actor will be stopped.
-pub type ActorResult<State> = Result<(State, Status), Box<StdError>>;
+pub type ActorResult<State> = Result<(State, Status), StdError>;
 
 #[cfg(test)]
 mod tests {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,13 +26,7 @@
 //!   mutable reference to the state of the actor. The state needs to live at least as long as 
 //!   the future and our research could find no way to do this easily. So now when the actor 
 //!   returns a status it will return the new state as well (Erlang style). See the examples for
-//!   more info.  The signature for the processor is now: 
-//!   ```rust
-//!       impl<F, S, R> Processor<S, R> for F where
-//!           S: Send + Sync,
-//!           R: Future<Output = AxiomResult<S>> + Send + 'static,
-//!           F: (FnMut(S, Context, Message) -> R) + Send + Sync + 'static  {} 
-//!   ```
+//!   more info.
 //!   * The user should take note that their actor will run now when it is POLLED and not
 //!   immediately as this may have some effect on the actor. Although depending on timing in actor
 //!   systems is chancy at best anyway, it's even more unreliable now. 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -205,7 +205,6 @@
 //! 7. **A huge emphasis is put on crate user ergonomics.** Axiom should be easy to use.
 
 use serde::{Deserialize, Serialize};
-use std::sync::RwLock;
 
 pub use crate::actors::Aid;
 pub use crate::actors::Context;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -223,51 +223,6 @@ pub mod system;
 
 pub mod prelude;
 
-/// Errors returned by the Aid
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub enum AidError {
-    /// This error is returned when a message cannot be converted to bincode. This will happen if
-    /// the message is not Serde serializable and the user has not implemented ActorMessage to
-    /// provide the correct implementation.
-    CantConvertToBincode,
-
-    /// This error is returned when a message cannot be converted from bincode. This will happen
-    /// ifg the message is not Serde serializable and the user has not implemented ActorMessage to
-    /// provide the correct implementation.
-    CantConvertFromBincode,
-
-    /// Error sent when attempting to send to an actor that has already been stopped. A stopped
-    /// actor cannot accept any more messages and is shut down. The holder of an [`Aid`] to
-    /// a stopped actor should throw the [`Aid`] away as the actor can never be started again.
-    ActorAlreadyStopped,
-
-    /// Error returned when an Aid is not local and a user is trying to do operations that
-    /// only work on local Aid instances.
-    AidNotLocal,
-
-    /// Used when unable to send to an actor's message channel within the scheduled timeout
-    /// configured in the actor system. This could result from the actor's channel being too
-    /// small to accommodate the message flow, the lack of thread count to process messages fast
-    /// enough to keep up with the flow or something wrong with the actor itself that it is
-    /// taking too long to clear the messages.
-    SendTimedOut(Aid),
-
-    /// Used when unable to schedule the actor for work in the work channel. This could be a
-    /// result of having a work channel that is too small to accommodate the number of actors
-    /// being concurrently scheduled, not enough threads to process actors in the channel fast
-    /// enough or simply an actor that misbehaves, causing dispatcher threads to take a lot of
-    /// time or not finish at all.
-    UnableToSchedule,
-}
-
-impl std::fmt::Display for AidError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self)
-    }
-}
-
-impl std::error::Error for AidError {}
-
 /// A helper alias to ensure returned errors conform as needed.
 pub type StdError = Box<dyn Error + Send + Sync + 'static>;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -219,6 +219,9 @@ use std::any::Any;
 use std::error::Error;
 use std::fmt::{Display, Formatter};
 
+// Re-export futures so the user doesn't need to import it.
+pub use futures;
+
 pub mod actors;
 pub mod cluster;
 mod executor;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,22 +15,22 @@
 //! ### What's New
 //! * 2019-11-xx 0.2.0
 //!   * Massive internal refactor in order to support async Actors using Rust futures.
-//!   * BREAKING CHANGE: The signature for Processors has changed from references for `Context` and 
-//!   `Message` to values. For closures-as-actors, wrap the body in an `async` block. 
-//!   `move |...| {...}` becomes `|...| async move { ... }`. For regular function syntax, simply 
+//!   * BREAKING CHANGE: The signature for Processors has changed from references for `Context` and
+//!   `Message` to values. For closures-as-actors, wrap the body in an `async` block.
+//!   `move |...| {...}` becomes `|...| async move { ... }`. For regular function syntax, simply
 //!   add `async` in front of `fn`.
 //!   * BREAKING CHANGE: Due to the ongoing development around async closures, the user will have
 //!   to put an async block inside handlers that are closures. See the examples for more
-//!   information. 
+//!   information.
 //!   * BREAKING CHANGE: Due to the nature of futures, the actor's processor cannot be given a
-//!   mutable reference to the state of the actor. The state needs to live at least as long as 
-//!   the future and our research could find no way to do this easily. So now when the actor 
+//!   mutable reference to the state of the actor. The state needs to live at least as long as
+//!   the future and our research could find no way to do this easily. So now when the actor
 //!   returns a status it will return the new state as well (Erlang style). See the examples for
 //!   more info.
 //!   * The user should take note that their actor will run now when it is POLLED and not
 //!   immediately as this may have some effect on the actor. Although depending on timing in actor
-//!   systems is chancy at best anyway, it's even more unreliable now. 
-//! 
+//!   systems is chancy at best anyway, it's even more unreliable now.
+//!
 //! [Release Notes for All Versions](https://github.com/rsimmonsjr/axiom/blob/master/RELEASE_NOTES.md)
 //!
 //! # Getting Started
@@ -204,8 +204,8 @@
 //! architected code.  
 //! 7. **A huge emphasis is put on crate user ergonomics.** Axiom should be easy to use.
 
-use std::sync::RwLock;
 use serde::{Deserialize, Serialize};
+use std::sync::RwLock;
 
 pub use crate::actors::Aid;
 pub use crate::actors::Context;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -322,11 +322,18 @@ impl AssertCollect {
     }
 
     pub fn assert(&self, cond: bool, msg: impl Into<String>) {
-        self.tx.send((cond, msg.into())).unwrap()
+        let m = msg.into();
+        self.tx.send((cond, m.clone())).unwrap();
+
+        if !cond {
+            panic!("{}", m)
+        }
     }
 
-    pub fn panic(&self, msg: impl Into<String>) {
-        self.tx.send((false, msg.into())).unwrap()
+    pub fn panic(&self, msg: impl Into<String>) -> ! {
+        let m = msg.into();
+        self.tx.send((false, m.clone())).unwrap();
+        panic!("{}", m)
     }
 
     pub fn collect(&self) {
@@ -477,8 +484,7 @@ mod tests {
                     // want the most frequently received messages first.
                     Ok((state, Status::Done))
                 } else {
-                    t.panic("Failed to dispatch properly");
-                    Ok((state, Status::Stop))
+                    t.panic("Failed to dispatch properly")
                 }
             }
         };
@@ -546,8 +552,7 @@ mod tests {
                     // want the most frequently received messages first.
                     Ok((self, Status::Done))
                 } else {
-                    self.tracker.panic("Failed to dispatch properly");
-                    Ok((self, Status::Stop))
+                    self.tracker.panic("Failed to dispatch properly")
                 }
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -379,8 +379,8 @@ mod tests {
         while aid.received().unwrap() < count as usize {
             if Instant::elapsed(&start) > duration {
                 return Err(format!(
-                    "Timed out! count: {} timeout_ms: {}",
-                    count, timeout_ms
+                    "Timed out after {}ms! Messages received: {}; Messages expected: {}",
+                    timeout_ms, aid.received().unwrap(), count
                 ));
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -227,7 +227,6 @@
 //! 7. **A huge emphasis is put on crate user ergonomics.** Axiom should be easy to use.
 
 use std::sync::RwLock;
-
 use serde::{Deserialize, Serialize};
 
 pub use crate::actors::Aid;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,7 +61,7 @@
 //! Axiom in only a few lines of code.
 //!
 //! ```rust
-//! use axiom::*;
+//! use axiom::prelude::*;
 //! use std::sync::Arc;
 //! use std::time::Duration;
 //!
@@ -108,7 +108,7 @@
 //! handles a couple of different message types:
 //!
 //! ```rust
-//! use axiom::*;
+//! use axiom::prelude::*;
 //! use std::sync::Arc;
 //!
 //! let system = ActorSystem::create(ActorSystemConfig::default().thread_pool_size(2));
@@ -206,14 +206,6 @@
 
 use serde::{Deserialize, Serialize};
 
-pub use crate::actors::Aid;
-pub use crate::actors::Context;
-pub use crate::actors::Status;
-pub use crate::message::Message;
-pub use crate::system::ActorSystem;
-pub use crate::system::ActorSystemConfig;
-pub use crate::system::SystemMsg;
-pub use crate::system::WireMessage;
 use secc::{SeccReceiver, SeccSender};
 use std::any::Any;
 use std::error::Error;
@@ -221,12 +213,15 @@ use std::fmt::{Display, Formatter};
 
 // Re-export futures so the user doesn't need to import it.
 pub use futures;
+use prelude::*;
 
 pub mod actors;
 pub mod cluster;
 mod executor;
 pub mod message;
 pub mod system;
+
+pub mod prelude;
 
 /// Errors returned by the Aid
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -380,7 +375,9 @@ mod tests {
             if Instant::elapsed(&start) > duration {
                 return Err(format!(
                     "Timed out after {}ms! Messages received: {}; Messages expected: {}",
-                    timeout_ms, aid.received().unwrap(), count
+                    timeout_ms,
+                    aid.received().unwrap(),
+                    count
                 ));
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,50 +13,30 @@
 //! rather a new implementation deriving inspiration from the good parts of those projects.
 //!
 //! ### What's New
-//! * 2019-09-27 0.1.0
-//!   * A lot of breaking changes have been introduced in an effort to keep them all in one release
-//!   so that the API can stabilize. Please see examples and other sources for help in integrating
-//!   all of the changes listed below.
-//!   * BREAKING CHANGE: `ActorId` has been renamed to `Aid` to facilitate communication and lower
-//!   confusion between the `uuid` field in the `Aid` and the `Aid` itself.
-//!   * BREAKING CHANGE: `Status::Processed` has been renamed to `Status::Done`.
-//!   * BREAKING CHANGE: `Status::Skipped` has been renamed to `Status::Skip`.
-//!   * BREAKING CHANGE: `Status::ResetSkip` has been renamed to `Status::Reset`.
-//!   * BREAKING CHANGE: `ActorError` has been moved to top level and renamed to `AxiomError`.
-//!   * BREAKING CHANGE: `find_by_name` and `find_by_uuid` have been removed from `Aid` as the
-//!   mechanism for looking up actors doesn't make sense the way it was before.
-//!   * BREAKING CHANGE: `MessageContent` was unintentionally public and is now private.
-//!   * BREAKING CHANGE: Changed `Processor` to take a `&Context` rather than `Aid`.
-//!   * BREAKING CHANGE: The `send`, `send_new` and `send_after` methods now return a result type
-//!   that the user must manage.
-//!   * BREAKING CHANGE: All actor processors now should return `AxiomResult` which will allow them
-//!   to use the `?` syntax for all functions that return `AxiomError` and return their own errors.
-//!   * BREAKING CHANGE: Actors are now spawned with the builder pattern. This allows the
-//!   configuration of an actor and leaves the door open for future flexibility. See documentation
-//!   for more details.
-//!   * Created a `Context` type that holds references to the `Aid` and `ActorSystem`.
-//!   * `Processor` functions can get a reference to the `Aid` of the actor from `Context`.
-//!   * `Processor` functions can get a reference to the `ActorSystem` from `Context`.
-//!   * The methods `find_aid_by_uuid` and `find_aid_by_name` are added to the `ActorSystem`.
-//!   * Calling `system.init_current()` is unneeded unless deserializing `Aid`s outside a
-//!   `Processor`.
-//!   * Metrics methods like `received()` in `Aid` return `Result` instead of using `panic!`.
-//!   * Changed internal maps to use crate `dashmap` which expands dependencies but increases
-//!   performance.
-//!   * New methods `send_new` and `send_new_after` are available to shorten boilerplate.
-//!   * Added a named system actor, which is registered under the name `System`, that is started
-//!   as the 1st actor in an `ActorSystem`.
-//!   * Added a method `system_actor_aid` to easily look up the `System` actor.
-//!   * Added additional configuration options to `ActorSystemConfig`.
-//!   * System will warn if an actor takes longer than the configured `warn_threshold` to process a
-//!   message.
-//!   * Instead of processing one message per receive, the system will now process pending messages
-//!   up until the configured `time_slice`, allowing optimized processing for quick messages.
-//!   * The default `message_channel_size` for actors is now configurable for the actor system as
-//!   a whole.
-//!   * Instead of waiting forever on a send, the system will wait for the configured
-//!   `send_timeout` before returning a timeout error to the caller.
-//!
+//! * 2019-11-xx 0.2.0
+//!   * Massive internal refactor in order to support async Actors using Rust futures.
+//!   * BREAKING CHANGE: The signature for Processors has changed from references for `Context` and 
+//!   `Message` to values. For closures-as-actors, wrap the body in an `async` block. 
+//!   `move |...| {...}` becomes `|...| async move { ... }`. For regular function syntax, simply 
+//!   add `async` in front of `fn`.
+//!   * BREAKING CHANGE: Due to the ongoing development around async closures, the user will have
+//!   to put an async block inside handlers that are closures. See the examples for more
+//!   information. 
+//!   * BREAKING CHANGE: Due to the nature of futures, the actor's processor cannot be given a
+//!   mutable reference to the state of the actor. The state needs to live at least as long as 
+//!   the future and our research could find no way to do this easily. So now when the actor 
+//!   returns a status it will return the new state as well (Erlang style). See the examples for
+//!   more info.  The signature for the processor is now: 
+//!   ```rust
+//!       impl<F, S, R> Processor<S, R> for F where
+//!           S: Send + Sync,
+//!           R: Future<Output = AxiomResult<S>> + Send + 'static,
+//!           F: (FnMut(S, Context, Message) -> R) + Send + Sync + 'static  {} 
+//!   ```
+//!   * The user should take note that their actor will run now when it is POLLED and not
+//!   immediately as this may have some effect on the actor. Although depending on timing in actor
+//!   systems is chancy at best anyway, it's even more unreliable now. 
+//! 
 //! [Release Notes for All Versions](https://github.com/rsimmonsjr/axiom/blob/master/RELEASE_NOTES.md)
 //!
 //! # Getting Started
@@ -125,6 +105,10 @@
 //! message it returns the new state of the actor and the status after handling this message. In
 //! this case we didnt change the state so we just return it. Creating an Axiom actor is literally
 //! that easy but there is a lot more functionality available as well.
+//!
+//! Keep in mind that if you are capturing variables from the environment you will have to wrap
+//! the `async move {}` block in another block and then move your variables into the first block.
+//! Please see the test cases for more examples of this.
 //!
 //! If you want to create an actor with a struct that is simple as well. Let's create one that
 //! handles a couple of different message types:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -330,7 +330,7 @@ impl AssertCollect {
     }
 
     pub fn collect(&self) {
-        while let Ok((cond, s)) = self.rx.receive_await() {
+        while let Ok((cond, s)) = self.rx.receive() {
             assert!(cond, "{}", s);
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -222,16 +222,16 @@ mod executor;
 pub mod message;
 pub mod system;
 
-/// Errors returned by various parts of Axiom.
+/// Errors returned by the Aid
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub enum AxiomError {
+pub enum AidError {
     /// This error is returned when a message cannot be converted to bincode. This will happen if
     /// the message is not Serde serializable and the user has not implemented ActorMessage to
     /// provide the correct implementation.
     CantConvertToBincode,
 
     /// This error is returned when a message cannot be converted from bincode. This will happen
-    /// ifg the message is not Serde serailizable and the user has not implemented ActorMessage to
+    /// ifg the message is not Serde serializable and the user has not implemented ActorMessage to
     /// provide the correct implementation.
     CantConvertFromBincode,
 
@@ -239,11 +239,6 @@ pub enum AxiomError {
     /// actor cannot accept any more messages and is shut down. The holder of an [`Aid`] to
     /// a stopped actor should throw the [`Aid`] away as the actor can never be started again.
     ActorAlreadyStopped,
-
-    /// An error returned when an actor is already using a local name at the time the user tries
-    /// to register that name for a new actor. The error contains the name that was attempted
-    /// to be registered.
-    NameAlreadyUsed(String),
 
     /// Error returned when an Aid is not local and a user is trying to do operations that
     /// only work on local Aid instances.
@@ -264,13 +259,13 @@ pub enum AxiomError {
     UnableToSchedule,
 }
 
-impl std::fmt::Display for AxiomError {
+impl std::fmt::Display for AidError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{:?}", self)
     }
 }
 
-impl std::error::Error for AxiomError {
+impl std::error::Error for AidError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         None
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -290,7 +290,7 @@ mod tests {
 
     pub fn init_test_log() {
         let _ = env_logger::builder()
-            .filter_level(LevelFilter::Debug)
+            .filter_level(LevelFilter::Warn)
             .is_test(true)
             .try_init();
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -350,7 +350,7 @@ mod tests {
 
         // The actor will get two messages including the Start message.
         await_received(&aid, 2, 1000).unwrap();
-        system.trigger_and_await_shutdown();
+        system.trigger_and_await_shutdown(None);
     }
 
     /// This test shows how the simplest struct-based actor can be built and used. This actor
@@ -378,7 +378,7 @@ mod tests {
         aid.send_new(11).unwrap();
 
         await_received(&aid, 2, 1000).unwrap();
-        system.trigger_and_await_shutdown();
+        system.trigger_and_await_shutdown(None);
     }
 
     /// This test shows how a closure based actor can be created to process different kinds of
@@ -430,7 +430,7 @@ mod tests {
         assert_eq!(4, aid.sent().unwrap());
 
         await_received(&aid, 4, 1000).unwrap();
-        system.trigger_and_await_shutdown();
+        system.trigger_and_await_shutdown(None);
     }
 
     /// This test shows how a struct-based actor can be used and process different kinds of
@@ -490,7 +490,7 @@ mod tests {
         aid.send_new(false).unwrap();
 
         await_received(&aid, 4, 1000).unwrap();
-        system.trigger_and_await_shutdown();
+        system.trigger_and_await_shutdown(None);
     }
 
     /// Tests and demonstrates the process to create a closure that captures the environment
@@ -517,7 +517,7 @@ mod tests {
 
         aid.send_new(11).unwrap();
         await_received(&target_aid, 2, 1000).unwrap();
-        system.trigger_and_await_shutdown();
+        system.trigger_and_await_shutdown(None);
     }
 
     /// Tests an example where one actor starts another actor, the actors exchange a simple
@@ -579,7 +579,7 @@ mod tests {
 
         let system = ActorSystem::create(ActorSystemConfig::default().thread_pool_size(2));
         system.spawn().with((), ping).unwrap();
-        system.await_shutdown();
+        system.await_shutdown(None);
 
         assert_eq!(2 + 2, 4);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -265,7 +265,7 @@ impl std::fmt::Display for AidError {
     }
 }
 
-impl std::error::Error for AidError { }
+impl std::error::Error for AidError {}
 
 /// A helper alias to ensure returned errors conform as needed.
 pub type StdError = Box<dyn Error + Send + Sync + 'static>;

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,13 +1,12 @@
 //! Defines the types associated with messages sent to actors.
 
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::any::{Any, TypeId};
 use std::collections::hash_map::DefaultHasher;
 use std::hash::Hash;
 use std::hash::Hasher;
 use std::sync::{Arc, RwLock};
-
-use serde::de::DeserializeOwned;
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 pub trait ActorMessage: Send + Sync + Any {
     /// Gets a bincode serialized version of the message.

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,6 +1,6 @@
 //! Defines the types associated with messages sent to actors.
 
-use crate::AxiomError;
+use crate::AidError;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::any::{Any, TypeId};
@@ -14,14 +14,14 @@ pub trait ActorMessage: Send + Sync + Any {
     /// Gets a bincode serialized version of the message and returns it in a result or an error
     /// indicating what went wrong.
     fn to_bincode(&self) -> Result<Vec<u8>, Box<dyn Error>> {
-        Err(Box::new(AxiomError::CantConvertToBincode))
+        Err(Box::new(AidError::CantConvertToBincode))
     }
 
     fn from_bincode(_data: &Vec<u8>) -> Result<Self, Box<dyn Error>>
     where
         Self: Sized,
     {
-        Err(Box::new(AxiomError::CantConvertFromBincode))
+        Err(Box::new(AidError::CantConvertFromBincode))
     }
 }
 

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,6 +1,8 @@
 pub use crate::actors::Aid;
+pub use crate::actors::AidError;
 pub use crate::actors::Context;
 pub use crate::actors::Status;
+pub use crate::executor::ShutdownResult;
 pub use crate::message::Message;
 pub use crate::system::ActorSystem;
 pub use crate::system::ActorSystemConfig;
@@ -8,5 +10,5 @@ pub use crate::system::SystemError;
 pub use crate::system::SystemMsg;
 pub use crate::system::WireMessage;
 pub use crate::ActorResult;
-pub use crate::AidError;
+pub use crate::Panic;
 pub use crate::StdError;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,0 +1,12 @@
+pub use crate::actors::Aid;
+pub use crate::actors::Context;
+pub use crate::actors::Status;
+pub use crate::message::Message;
+pub use crate::system::ActorSystem;
+pub use crate::system::ActorSystemConfig;
+pub use crate::system::SystemError;
+pub use crate::system::SystemMsg;
+pub use crate::system::WireMessage;
+pub use crate::ActorResult;
+pub use crate::AidError;
+pub use crate::StdError;

--- a/src/system.rs
+++ b/src/system.rs
@@ -1043,19 +1043,23 @@ mod tests {
     }
 
     /// This test verifies that the system can send a message after a particular delay.
-    /// FIXME need separate test for remotes.
+    // FIXME need separate test for remotes.
     #[test]
     fn test_send_after() {
         init_test_log();
 
+        info!("Preparing test");
         let system = ActorSystem::create(ActorSystemConfig::default().thread_pool_size(2));
         let aid = system.spawn().name("A").with((), simple_handler).unwrap();
         await_received(&aid, 1, 1000).unwrap();
+        info!("Test prepared, sending delayed message");
 
         system.send_after(Message::new(11), aid.clone(), Duration::from_millis(10));
+        info!("Sleeping for initial check");
         thread::sleep(Duration::from_millis(5));
         assert_eq!(1, aid.received().unwrap());
-        thread::sleep(Duration::from_millis(20));
+        info!("Sleeping till we're 100% sure we should have the message");
+        thread::sleep(Duration::from_millis(15));
         assert_eq!(2, aid.received().unwrap());
 
         system.trigger_and_await_shutdown(None);
@@ -1069,7 +1073,6 @@ mod tests {
         init_test_log();
 
         let system = ActorSystem::create(ActorSystemConfig::default().thread_pool_size(2));
-        thread::sleep(Duration::from_millis(10));
 
         let aid1 = system.spawn().name("A").with((), simple_handler).unwrap();
         await_received(&aid1, 1, 1000).unwrap();
@@ -1078,11 +1081,9 @@ mod tests {
 
         aid1.send_after(Message::new(11), Duration::from_millis(200))
             .unwrap();
-        thread::sleep(Duration::from_millis(5));
 
-        aid2.send_after(Message::new(11), Duration::from_millis(50))
+        aid2.send_after(Message::new(11), Duration::from_millis(10))
             .unwrap();
-        thread::sleep(Duration::from_millis(5));
 
         assert_eq!(1, aid1.received().unwrap());
         assert_eq!(1, aid2.received().unwrap());

--- a/src/system.rs
+++ b/src/system.rs
@@ -8,6 +8,15 @@
 //!
 //! The user should refer to test cases and examples as "how-to" guides for using Axiom.
 
+use crate::actors::*;
+use crate::executor::{AxiomExecutor, ShutdownResult};
+use crate::message::*;
+use crate::*;
+use dashmap::DashMap;
+use log::{debug, error, info, trace, warn};
+use once_cell::sync::OnceCell;
+use secc::*;
+use serde::{Deserialize, Serialize};
 use std::collections::{BinaryHeap, HashSet};
 use std::fmt;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -15,16 +24,7 @@ use std::sync::{Arc, Condvar, Mutex};
 use std::thread;
 use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
-use dashmap::DashMap;
-use log::{debug, error, info, warn, trace};
-use once_cell::sync::OnceCell;
-use secc::*;
-use serde::{Deserialize, Serialize};
 use uuid::Uuid;
-use crate::actors::*;
-use crate::executor::{AxiomExecutor, ShutdownResult};
-use crate::message::*;
-use crate::*;
 
 // Holds an [`ActorSystem`] in a [`std::thread_local`] so that the [`Aid`] deserializer and
 // other types can obtain a clone if needed at any time. This will be automatically set for all

--- a/src/system.rs
+++ b/src/system.rs
@@ -8,15 +8,16 @@
 //!
 //! The user should refer to test cases and examples as "how-to" guides for using Axiom.
 
-use crate::actors::*;
-use crate::executor::{AxiomExecutor, ShutdownResult};
-use crate::message::*;
-use crate::*;
+use crate::actors::{Actor, ActorBuilder, ActorStream};
+use crate::executor::AxiomExecutor;
+use crate::prelude::*;
 use dashmap::DashMap;
 use log::{debug, error, info, trace, warn};
 use once_cell::sync::OnceCell;
+use secc::{SeccReceiver, SeccSender};
 use serde::{Deserialize, Serialize};
 use std::collections::{BinaryHeap, HashSet};
+use std::error::Error;
 use std::fmt;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Condvar, Mutex};

--- a/src/system.rs
+++ b/src/system.rs
@@ -830,6 +830,11 @@ impl ActorSystem {
         data.push(entry);
         condvar.notify_all();
     }
+
+    #[cfg(test)]
+    pub(crate) fn executor(&self) -> &AxiomExecutor {
+        &self.data.executor
+    }
 }
 
 impl fmt::Debug for ActorSystem {

--- a/src/system.rs
+++ b/src/system.rs
@@ -1159,7 +1159,6 @@ mod tests {
         init_test_log();
 
         let tracker = AssertCollect::new();
-
         async fn monitor_handler(
             state: (Aid, AssertCollect),
             _: Context,
@@ -1175,14 +1174,10 @@ mod tests {
                         Ok((state, Status::Done))
                     }
                     SystemMsg::Start => Ok((state, Status::Done)),
-                    _ => {
-                        state.1.panic("Received some other message!");
-                        Ok((state, Status::Stop))
-                    }
+                    _ => state.1.panic("Received some other message!"),
                 }
             } else {
-                state.1.panic("Received some other message!");
-                Ok((state, Status::Stop))
+                state.1.panic("Received some other message!")
             }
         }
 
@@ -1287,8 +1282,7 @@ mod tests {
                     } else if let Some(_) = message.content_as::<SystemMsg>() {
                         Ok(((), Status::Done))
                     } else {
-                        t.panic("Unexpected message received!");
-                        Ok(((), Status::Stop))
+                        t.panic("Unexpected message received!")
                     }
                 }
             })
@@ -1319,8 +1313,7 @@ mod tests {
                         _ => future::ok(((), Status::Done)),
                     }
                 } else {
-                    t.panic("Unexpected message received!");
-                    future::ok(((), Status::Stop))
+                    t.panic("Unexpected message received!")
                 }
             })
             .unwrap();
@@ -1375,14 +1368,10 @@ mod tests {
                                     context.system.trigger_shutdown();
                                     Ok(((), Status::Done))
                                 } else {
-                                    t.panic("Didn't find AID.");
-                                    Ok(((), Status::Stop))
+                                    t.panic("Didn't find AID.")
                                 }
                             }
-                            _ => {
-                                t.panic("Unexpected message received!");
-                                Ok(((), Status::Stop))
-                            }
+                            _ => t.panic("Unexpected message received!"),
                         }
                     } else if let Some(msg) = message.content_as::<SystemMsg>() {
                         debug!("Actor started, attempting to send FindByName request");
@@ -1395,12 +1384,10 @@ mod tests {
                             ));
                             Ok(((), Status::Done))
                         } else {
-                            t.panic("Unexpected message received!");
-                            Ok(((), Status::Stop))
+                            t.panic("Unexpected message received!")
                         }
                     } else {
-                        t.panic("Unexpected message received!");
-                        Ok(((), Status::Stop))
+                        t.panic("Unexpected message received!")
                     }
                 }
             })

--- a/src/system.rs
+++ b/src/system.rs
@@ -15,14 +15,12 @@ use std::sync::{Arc, Condvar, Mutex};
 use std::thread;
 use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
-
 use dashmap::DashMap;
 use log::{debug, error, info, warn};
 use once_cell::sync::OnceCell;
 use secc::*;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
-
 use crate::actors::*;
 use crate::executor::{AxiomExecutor, ShutdownResult};
 use crate::message::*;

--- a/src/system.rs
+++ b/src/system.rs
@@ -16,7 +16,7 @@ use std::thread;
 use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
 use dashmap::DashMap;
-use log::{debug, error, info, warn};
+use log::{debug, error, info, warn, trace};
 use once_cell::sync::OnceCell;
 use secc::*;
 use serde::{Deserialize, Serialize};

--- a/src/system.rs
+++ b/src/system.rs
@@ -1224,9 +1224,11 @@ mod tests {
             .spawn()
             .with((), |_: (), _: Context, msg: Message| {
                 if let Some(_) = msg.content_as::<SystemMsg>() {
+                    debug!("Not panicking this time");
                     return future::ok(((), Status::Done));
                 }
 
+                debug!("About to panic");
                 panic!("I panicked")
             })
             .unwrap();

--- a/src/system.rs
+++ b/src/system.rs
@@ -659,7 +659,7 @@ impl ActorSystem {
     ///
     /// # Examples
     /// ```
-    /// use axiom::*;
+    /// use axiom::prelude::*;
     ///
     /// let system = ActorSystem::create(ActorSystemConfig::default().thread_pool_size(2));
     ///

--- a/src/system.rs
+++ b/src/system.rs
@@ -49,10 +49,7 @@ pub enum SystemMsg {
 
     /// A message sent to an actor when a monitored actor is stopped and thus not able to
     /// process additional messages. The value is the `aid` of the actor that stopped.
-    Stopped {
-        aid: Aid,
-        error: Option<String>,
-    },
+    Stopped { aid: Aid, error: Option<String> },
 }
 
 /// A type used for sending messages to other actor systems.
@@ -222,7 +219,7 @@ impl std::fmt::Display for SystemError {
     }
 }
 
-impl Error for SystemError { }
+impl Error for SystemError {}
 
 /// Information for communicating with a remote actor system.
 pub struct RemoteInfo {
@@ -625,14 +622,20 @@ impl ActorSystem {
     }
 
     /// Triggers a shutdown of the system and returns only when all Reactors have shutdown.
-    pub fn trigger_and_await_shutdown(&self, timeout: impl Into<Option<Duration>>)
-        -> ShutdownResult {
+    pub fn trigger_and_await_shutdown(
+        &self,
+        timeout: impl Into<Option<Duration>>,
+    ) -> ShutdownResult {
         self.trigger_shutdown();
         self.await_shutdown(timeout)
     }
 
     // A internal helper to register an actor in the actor system.
-    pub(crate) fn register_actor(&self, actor: Arc<Actor>, stream: ActorStream) -> Result<Aid, SystemError> {
+    pub(crate) fn register_actor(
+        &self,
+        actor: Arc<Actor>,
+        stream: ActorStream,
+    ) -> Result<Aid, SystemError> {
         let aids_by_name = &self.data.aids_by_name;
         let actors_by_aid = &self.data.actors_by_aid;
         let aids_by_uuid = &self.data.aids_by_uuid;
@@ -691,10 +694,7 @@ impl ActorSystem {
     pub(crate) fn schedule(&self, aid: Aid) {
         let actors_by_aid = &self.data.actors_by_aid;
         if actors_by_aid.contains_key(&aid) {
-            self
-                .data
-                .executor
-                .wake(aid);
+            self.data.executor.wake(aid);
         } else {
             // The actor was removed from the map so ignore the problem and just log
             // a warning.
@@ -737,7 +737,10 @@ impl ActorSystem {
         if let Some((_, monitoring)) = self.data.monitoring_by_monitored.remove(&aid) {
             let error = error.into().map(|e| format!("{}", e));
             for m_aid in monitoring {
-                let value = SystemMsg::Stopped { aid: aid.clone(), error: error.clone() };
+                let value = SystemMsg::Stopped {
+                    aid: aid.clone(),
+                    error: error.clone(),
+                };
                 m_aid.send(Message::new(value)).unwrap_or_else(|error| {
                     error!(
                         "Could not send 'Stopped' to monitoring actor {}: Error: {:?}",

--- a/src/system.rs
+++ b/src/system.rs
@@ -371,7 +371,7 @@ impl ActorSystem {
 
     /// Starts a thread that monitors the delayed_messages and sends the messages when their
     /// delays have elapsed.
-    /// FIXME Add a graceful shutdown to this thread and notifications.
+    // FIXME Add a graceful shutdown to this thread and notifications.
     fn start_send_after_thread(&self) -> JoinHandle<()> {
         let system = self.clone();
         let delayed_messages = self.data.delayed_messages.clone();
@@ -475,7 +475,7 @@ impl ActorSystem {
     }
 
     /// Disconnects this actor system from the remote actor system with the given UUID.
-    /// FIXME Connectivity management needs a lot of work and testing.
+    // FIXME Connectivity management needs a lot of work and testing.
     pub fn disconnect(&self, system_uuid: Uuid) -> Result<(), AidError> {
         self.data.remotes.remove(&system_uuid);
         Ok(())
@@ -501,8 +501,7 @@ impl ActorSystem {
 
     /// A helper function to process a wire message from another actor system. The passed uuid
     /// is the uuid of the remote that sent the message.
-    ///
-    /// FIXME (Issue #74) Make error handling in ActorSystem::process_wire_message more robust.
+    // FIXME (Issue #74) Make error handling in ActorSystem::process_wire_message more robust.
     fn process_wire_message(&self, _uuid: &Uuid, wire_message: &WireMessage) {
         match wire_message {
             WireMessage::ActorMessage {
@@ -568,7 +567,7 @@ impl ActorSystem {
         condvar.notify_all();
     }
 
-    /// Awaits the Executor shutting down all Reactors. This is backed by a Barrier that Reactors
+    /// Awaits the Executor shutting down all Reactors. This is backed by a barrier that Reactors
     /// will wait on after [`ActorSystem::trigger_shutdown`] is called, blocking until all Reactors
     /// have stopped.
     pub fn await_shutdown(&self, timeout: impl Into<Option<Duration>>) -> ShutdownResult {
@@ -688,8 +687,7 @@ impl ActorSystem {
     /// 1 receivable message. If the actor has more receivable messages then this will not be
     /// needed to be called because the dispatcher threads will handle the process of resending
     /// the actor to the work channel.
-    ///
-    /// TODO Put tests verifying the resend on multiple messages.
+    // TODO Put tests verifying the resend on multiple messages.
     pub(crate) fn schedule(&self, aid: Aid) {
         let actors_by_aid = &self.data.actors_by_aid;
         if actors_by_aid.contains_key(&aid) {
@@ -721,7 +719,7 @@ impl ActorSystem {
 
     /// Internal implementation of stop_actor, so we have the ability to send an error along with
     /// the notification of stop.
-    pub(crate) fn internal_stop_actor(&self, aid: &Aid, error: impl Into<Option<Box<StdError>>>) {
+    pub(crate) fn internal_stop_actor(&self, aid: &Aid, error: impl Into<Option<StdError>>) {
         {
             let actors_by_aid = &self.data.actors_by_aid;
             let aids_by_uuid = &self.data.aids_by_uuid;
@@ -800,7 +798,7 @@ impl ActorSystem {
     }
 
     /// Asynchronously send a message to the system actors on all connected actor systems.
-    /// FIXME (Issue #72) Add try_send ability.
+    // FIXME (Issue #72) Add try_send ability.
     pub fn send_to_system_actors(&self, message: Message) {
         let remotes = &*self.data.remotes;
         trace!("Sending message to Remote System Actors");
@@ -860,7 +858,7 @@ enum SystemActorMessage {
 }
 
 /// A processor for the system actor.
-/// FIXME Issue #89: Refactor into a full struct based actor in another file.
+// FIXME Issue #89: Refactor into a full struct based actor in another file.
 async fn system_actor_processor(_: (), context: Context, message: Message) -> ActorResult<()> {
     if let Some(msg) = message.content_as::<SystemActorMessage>() {
         match &*msg {

--- a/src/system.rs
+++ b/src/system.rs
@@ -15,7 +15,6 @@ use crate::*;
 use dashmap::DashMap;
 use log::{debug, error, info, trace, warn};
 use once_cell::sync::OnceCell;
-use secc::*;
 use serde::{Deserialize, Serialize};
 use std::collections::{BinaryHeap, HashSet};
 use std::fmt;

--- a/src/system.rs
+++ b/src/system.rs
@@ -940,7 +940,7 @@ mod tests {
             .with((), |_state: (), context: Context, _: Message| {
                 async move {
                     // Block for enough time so we can test timeout twice
-                    thread::sleep(Duration::from_millis(100));
+                    sleep(100);
                     context.system.trigger_shutdown();
                     Ok(((), Status::Done))
                 }
@@ -1056,10 +1056,10 @@ mod tests {
 
         system.send_after(Message::new(11), aid.clone(), Duration::from_millis(10));
         info!("Sleeping for initial check");
-        thread::sleep(Duration::from_millis(5));
+        sleep(5);
         assert_eq!(1, aid.received().unwrap());
         info!("Sleeping till we're 100% sure we should have the message");
-        thread::sleep(Duration::from_millis(10));
+        sleep(10);
         assert_eq!(2, aid.received().unwrap());
 
         system.trigger_and_await_shutdown(None);
@@ -1090,11 +1090,11 @@ mod tests {
 
         // We overshoot the timing on the asserts because when the tests are run the CPU is
         // busy and the timing can be tricky.
-        thread::sleep(Duration::from_millis(15));
+        sleep(15);
         assert_eq!(1, aid1.received().unwrap());
         assert_eq!(2, aid2.received().unwrap());
 
-        thread::sleep(Duration::from_millis(50));
+        sleep(50);
         assert_eq!(2, aid1.received().unwrap());
         assert_eq!(2, aid2.received().unwrap());
 

--- a/src/system.rs
+++ b/src/system.rs
@@ -338,7 +338,7 @@ impl ActorSystem {
         };
 
         info!("ActorSystem {} has spawned", uuid);
-        system.data.executor.init(system.clone());
+        system.data.executor.init(&system);
 
         // We have the thread pool in a mutex to avoid a chicken & egg situation with the actor
         // system not being created yet but needed by the thread. We put this code in a block to


### PR DESCRIPTION
This is a massive overhaul of the internals, as well as significant changes to the API.

The most notable change is that Actor Processors are now Async, and the worker threads and channel are refactored into the Executor-Reactor pattern. @LucioFranco has agreed to do us the massive favour of reviewing these specific changes.

Other changes include breaking up AxiomError, and passing state by value (and expecting it returned back).

### Progress
- [x] Implement changes
- [x] Fix documentation
- [x] Fix tests
- [x] `cargo fmt`
- [x] Add new tests
  - [x] Sleeping Actors are returned
  - [x] Waiting Actors are woken after returning Pending
  - [x] Actors can panic (should turn into a `Panic` error for a Monitor)
  - [x] Reactors resume after running out of work (send a message after 150ms)
  - [x] Nested futures wake the Actor (nest another async block, then a future that threads a wakeup in 50ms)
- [x] Review logging and remove less-than-sound unwraps https://github.com/rsimmonsjr/axiom/issues/108
- [x] Release notes
