### PR TITLE
Add ergonomic return functions for Status

### DIFF
--- a/src/actors.rs
+++ b/src/actors.rs
@@ -58,6 +58,28 @@ pub enum Status {
     Stop,
 }
 
+impl Status {
+    /// Ergonomic shortcut for writing `(state, Status::Done)`
+    pub fn done<T>(state: T) -> (T, Status) {
+        (state, Status::Done)
+    }
+
+    /// Ergonomic shortcut for writing `(state, Status::Skip)`
+    pub fn skip<T>(state: T) -> (T, Status) {
+        (state, Status::Skip)
+    }
+
+    /// Ergonomic shortcut for writing `(state, Status::Reset)`
+    pub fn reset<T>(state: T) -> (T, Status) {
+        (state, Status::Reset)
+    }
+
+    /// Ergonomic shortcut for writing `(state, Status::Stop)`
+    pub fn stop<T>(state: T) -> (T, Status) {
+        (state, Status::Stop)
+    }
+}
+
 /// Errors returned by the Aid
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum AidError {
@@ -292,7 +314,7 @@ impl Aid {
     ///             if let Some(_) = message.content_as::<i32>() {
     ///                 context.system.trigger_shutdown();
     ///             }
-    ///             Ok((state, Status::Done))
+    ///             Ok(Status::done(state))
     ///        },
     ///     )
     ///     .unwrap();
@@ -358,7 +380,7 @@ impl Aid {
     ///             if let Some(_) = message.content_as::<i32>() {
     ///                 context.system.trigger_shutdown();
     ///             }
-    ///             Ok((state, Status::Done))
+    ///             Ok(Status::done(state))
     ///        },
     ///     )
     ///     .unwrap();
@@ -399,7 +421,7 @@ impl Aid {
     ///             if let Some(_) = message.content_as::<i32>() {
     ///                 context.system.trigger_shutdown();
     ///             }
-    ///             Ok((state, Status::Done))
+    ///             Ok(Status::done(state))
     ///        },
     ///     )
     ///     .unwrap();
@@ -442,7 +464,7 @@ impl Aid {
     ///             if let Some(_) = message.content_as::<i32>() {
     ///                 context.system.trigger_shutdown();
     ///             }
-    ///             Ok((state, Status::Done))
+    ///             Ok(Status::done(state))
     ///        },
     ///     )
     ///     .unwrap();
@@ -505,7 +527,7 @@ impl Aid {
     ///             if let Some(_) = message.content_as::<i32>() {
     ///                 context.system.trigger_shutdown();
     ///             }
-    ///             Ok((state, Status::Done))
+    ///             Ok(Status::done(state))
     ///        },
     ///     )
     ///     .unwrap();
@@ -547,7 +569,7 @@ impl Aid {
     ///             if let Some(_) = message.content_as::<i32>() {
     ///                 context.system.trigger_shutdown();
     ///             }
-    ///             Ok((state, Status::Done))
+    ///             Ok(Status::done(state))
     ///        },
     ///     )
     ///     .unwrap();
@@ -1042,7 +1064,7 @@ mod tests {
                     if let Some(_) = message.content_as::<i32>() {
                         context.system.trigger_shutdown();
                     }
-                    Ok(((), Status::Done))
+                    Ok(Status::done(()))
                 }
             })
             .unwrap();
@@ -1078,7 +1100,7 @@ mod tests {
                     if let Some(_) = message.content_as::<Foo>() {
                         context.system.trigger_shutdown();
                     }
-                    Ok(((), Status::Done))
+                    Ok(Status::done(()))
                 }
             })
             .unwrap();
@@ -1214,7 +1236,7 @@ mod tests {
                             }
                         }
                     }
-                    Ok((t, Status::Done))
+                    Ok(Status::done(t))
                 }
             })
             .unwrap();
@@ -1261,7 +1283,7 @@ mod tests {
                         Ok((t, Status::Stop))
                     } else if let Some(msg) = message.content_as::<SystemMsg>() {
                         match &*msg {
-                            SystemMsg::Start => Ok((t, Status::Done)),
+                            SystemMsg::Start => Ok(Status::done(t)),
                             m => t.panic(format!("unexpected message: {:?}", m)),
                         }
                     } else {
@@ -1307,8 +1329,8 @@ mod tests {
                 async move {
                     if let Some(msg) = message.content_as::<SystemMsg>() {
                         match &*msg {
-                            SystemMsg::Start => Ok((t, Status::Done)),
-                            SystemMsg::Stop => Ok((t, Status::Done)),
+                            SystemMsg::Start => Ok(Status::done(t)),
+                            SystemMsg::Stop => Ok(Status::done(t)),
                             m => t.panic(format!("unexpected message: {:?}", m)),
                         }
                     } else {

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -428,7 +428,7 @@ mod tests {
 
         fn poll(mut self: Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> Poll<Self::Output> {
             match &mut self.pending_count {
-                0 => Poll::Ready(Ok(((), Status::Done))),
+                0 => Poll::Ready(Ok(Status::done(()))),
                 count => {
                     *count -= 1;
                     debug!("Pending, {} times left", count);
@@ -489,7 +489,7 @@ mod tests {
             .with((), |_: (), _: Context, msg: Message| {
                 async move {
                     if let Some(_) = msg.content_as::<SystemMsg>() {
-                        return Ok(((), Status::Done));
+                        return Ok(Status::done(()));
                     }
 
                     PendingNTimes::new(1, 25).await

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,7 +72,7 @@
 //!     .with(
 //!         0 as usize,
 //!         |state: usize, _context: Context, _message: Message| async move {
-//!             Ok((state, Status::Done))
+//!             Ok(Status::done(state))
 //!         }
 //!     )
 //!     .unwrap();
@@ -124,12 +124,12 @@
 //!         } else {
 //!             self.value -= 1;
 //!         }
-//!         Ok((self, Status::Done))
+//!         Ok(Status::done(self))
 //!     }
 //!
 //!     fn handle_i32(mut self, message: i32) -> ActorResult<Self> {
 //!         self.value += message;
-//!         Ok((self, Status::Done))
+//!         Ok(Status::done(self))
 //!     }
 //!
 //!     async fn handle(mut self, _context: Context, message: Message) -> ActorResult<Self> {
@@ -312,7 +312,7 @@ mod tests {
     /// A function that just returns `Ok(Status::Done)` which can be used as a handler for
     /// a simple dummy actor.
     pub async fn simple_handler(_: (), _: Context, _: Message) -> ActorResult<()> {
-        Ok(((), Status::Done))
+        Ok(Status::done(()))
     }
 
     /// A utility that waits for a certain number of messages to arrive in a certain time and
@@ -360,7 +360,7 @@ mod tests {
         let aid = system
             .spawn()
             .with((), |_: (), _: Context, _: Message| {
-                async { Ok(((), Status::Done)) }
+                async { Ok(Status::done(())) }
             })
             .unwrap();
 
@@ -420,16 +420,16 @@ mod tests {
                 // Attempt to downcast to expected message.
                 if let Some(_msg) = message.content_as::<SystemMsg>() {
                     state += 1;
-                    Ok((state, Status::Done))
+                    Ok(Status::done(state))
                 } else if let Some(msg) = message.content_as::<i32>() {
                     t.assert(expected[state - 1] == *msg, "Unexpected message content");
                     t.assert(state == context.aid.received().unwrap(), "Unexpected state");
                     state += 1;
-                    Ok((state, Status::Done))
+                    Ok(Status::done(state))
                 } else if let Some(_msg) = message.content_as::<SystemMsg>() {
                     // Note that we put this last because it only is ever received once, we
                     // want the most frequently received messages first.
-                    Ok((state, Status::Done))
+                    Ok(Status::done(state))
                 } else {
                     t.panic("Failed to dispatch properly")
                 }
@@ -539,7 +539,7 @@ mod tests {
                 let tgt = aid_moved.clone();
                 async move {
                     tgt.send_new(11)?;
-                    Ok(((), Status::Done))
+                    Ok(Status::done(()))
                 }
             })
             .unwrap();
@@ -568,7 +568,7 @@ mod tests {
                 match &*msg {
                     PingPong::Pong => {
                         context.system.trigger_shutdown();
-                        Ok(((), Status::Done))
+                        Ok(Status::done(()))
                     }
                     _ => Err("Unexpected message".to_string().into()),
                 }
@@ -579,12 +579,12 @@ mod tests {
                         // Now we will spawn a new actor to handle our pong and send to it.
                         let pong_aid = context.system.spawn().with((), pong)?;
                         pong_aid.send_new(PingPong::Ping(context.aid.clone()))?;
-                        Ok(((), Status::Done))
+                        Ok(Status::done(()))
                     }
-                    _ => Ok(((), Status::Done)),
+                    _ => Ok(Status::done(())),
                 }
             } else {
-                Ok(((), Status::Done))
+                Ok(Status::done(()))
             }
         }
 
@@ -593,12 +593,12 @@ mod tests {
                 match &*msg {
                     PingPong::Ping(from) => {
                         from.send_new(PingPong::Pong)?;
-                        Ok(((), Status::Done))
+                        Ok(Status::done(()))
                     }
                     _ => Err("Unexpected message".into()),
                 }
             } else {
-                Ok(((), Status::Done))
+                Ok(Status::done(()))
             }
         }
 

--- a/src/system.rs
+++ b/src/system.rs
@@ -668,7 +668,7 @@ impl ActorSystem {
     ///
     /// async fn handler(mut count: usize, _: Context, _: Message) -> ActorResult<usize> {
     ///     count += 1;
-    ///     Ok((count, Status::Done))
+    ///     Ok(Status::done(count))
     /// }
     ///
     /// let state = 0 as usize;
@@ -896,7 +896,7 @@ mod tests {
                     // Block for enough time so we can test timeout twice
                     sleep(100);
                     context.system.trigger_shutdown();
-                    Ok(((), Status::Done))
+                    Ok(Status::done(()))
                 }
             })
             .unwrap();
@@ -1120,9 +1120,9 @@ mod tests {
                             .1
                             .assert(Aid::ptr_eq(&state.0, aid), "Pointers are not equal!");
                         state.1.assert(error.is_none(), "Actor was errored!");
-                        Ok((state, Status::Done))
+                        Ok(Status::done(state))
                     }
-                    SystemMsg::Start => Ok((state, Status::Done)),
+                    SystemMsg::Start => Ok(Status::done(state)),
                     _ => state.1.panic("Received some other message!"),
                 }
             } else {
@@ -1174,7 +1174,7 @@ mod tests {
             .with((), |_: (), _: Context, msg: Message| {
                 if let Some(_) = msg.content_as::<SystemMsg>() {
                     debug!("Not panicking this time");
-                    return future::ok(((), Status::Done));
+                    return future::ok(Status::done(()));
                 }
 
                 debug!("About to panic");
@@ -1193,9 +1193,9 @@ mod tests {
                                 error.as_ref().unwrap() == "I panicked",
                                 "Error message does not match",
                             );
-                            future::ok((state, Status::Stop))
+                            future::ok(Status::stop(state))
                         }
-                        SystemMsg::Start => future::ok((state, Status::Done)),
+                        SystemMsg::Start => future::ok(Status::done(state)),
                         _ => t.panic("Unexpected message received!"),
                     }
                 } else {
@@ -1275,9 +1275,9 @@ mod tests {
                     if let Some(msg) = message.content_as::<Request>() {
                         msg.reply_to.send_new(Reply {}).unwrap();
                         context.system.trigger_shutdown();
-                        Ok(((), Status::Stop))
+                        Ok(Status::stop(()))
                     } else if let Some(_) = message.content_as::<SystemMsg>() {
-                        Ok(((), Status::Done))
+                        Ok(Status::done(()))
                     } else {
                         t.panic("Unexpected message received!")
                     }
@@ -1294,7 +1294,7 @@ mod tests {
                 if let Some(_) = message.content_as::<Reply>() {
                     debug!("Received reply, shutting down");
                     context.system.trigger_shutdown();
-                    future::ok(((), Status::Stop))
+                    future::ok(Status::stop(()))
                 } else if let Some(msg) = message.content_as::<SystemMsg>() {
                     match &*msg {
                         SystemMsg::Start => {
@@ -1305,9 +1305,9 @@ mod tests {
                                     reply_to: context.aid.clone(),
                                 })
                                 .unwrap();
-                            future::ok(((), Status::Done))
+                            future::ok(Status::done(()))
                         }
-                        _ => future::ok(((), Status::Done)),
+                        _ => future::ok(Status::done(())),
                     }
                 } else {
                     t.panic("Unexpected message received!")
@@ -1336,9 +1336,9 @@ mod tests {
                 async move {
                     if let Some(_) = message.content_as::<bool>() {
                         context.system.trigger_shutdown();
-                        Ok(((), Status::Stop))
+                        Ok(Status::stop(()))
                     } else {
-                        Ok(((), Status::Done))
+                        Ok(Status::done(()))
                     }
                 }
             })
@@ -1363,7 +1363,7 @@ mod tests {
                                     );
                                     target.send_new(true).unwrap();
                                     context.system.trigger_shutdown();
-                                    Ok(((), Status::Done))
+                                    Ok(Status::done(()))
                                 } else {
                                     t.panic("Didn't find AID.")
                                 }
@@ -1379,7 +1379,7 @@ mod tests {
                                     name: "A".to_string(),
                                 },
                             ));
-                            Ok(((), Status::Done))
+                            Ok(Status::done(()))
                         } else {
                             t.panic("Unexpected message received!")
                         }


### PR DESCRIPTION
Adds Functions that create shorthand from the obtuse `(state, Status::X)` to `Status::x(state)`