### PR TITLE
Fix panic catching and pending handlers

### DIFF
--- a/src/actors.rs
+++ b/src/actors.rs
@@ -18,7 +18,7 @@ use std::cell::UnsafeCell;
 use std::fmt::Debug;
 use std::future::Future;
 use std::hash::{Hash, Hasher};
-use std::marker::{Send, Sync, PhantomData};
+use std::marker::{Send, Sync};
 use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::pin::Pin;
 use std::ptr;
@@ -27,7 +27,6 @@ use std::sync::Arc;
 use std::task::Poll;
 use std::time::Duration;
 use uuid::Uuid;
-use std::ops::DerefMut;
 
 /// Status of the message and potentially the actor as a resulting from processing a message
 /// with the actor.
@@ -888,20 +887,20 @@ impl Actor {
             let s = unsafe { (*state.0).take() }.expect("State cell was empty");
             let future = catch_unwind(AssertUnwindSafe(|| (processor)(s, ctx, msg)));
             async move {
-                let result = match future {
-                    Ok(future) => {
-                        let pending = PanicSafeFuture {
-                            future: Box::pin(future),
-                            __state_phantom_data: PhantomData::<S>::default(),
-                        };
-                        pending.await
+                match future {
+                    Ok(future) => match AssertUnwindSafe(future).catch_unwind().await {
+                        Ok(x) => x,
+                        Err(panic) => {
+                            warn!("Actor panicked! Catching as error");
+                            Err(Panic::from(panic).into())
+                        }
                     },
                     Err(err) => {
                         warn!("Actor panicked! Catching as error");
                         Err(Panic::from(err).into())
                     }
-                };
-                result.map(|(s, status)| {
+                }
+                .map(|(s, status)| {
                     unsafe { ptr::write(state.0, Some(s)) };
                     status
                 })
@@ -926,26 +925,6 @@ impl Actor {
         };
 
         (Arc::new(actor), stream)
-    }
-}
-
-struct PanicSafeFuture<S, F>
-where
-    F: Future<Output=ActorResult<S>>,
-{
-    future: Pin<Box<F>>,
-    __state_phantom_data: PhantomData<S>,
-}
-
-impl<S, F: Future<Output=ActorResult<S>>> Future for PanicSafeFuture<S, F> {
-    type Output = F::Output;
-
-    fn poll(mut self: Pin<&mut Self>, cx: &mut std::task::Context) -> Poll<Self::Output> {
-        let x = self.future.as_mut();
-        match catch_unwind(AssertUnwindSafe(|| x.poll(cx))) {
-            Ok(result) => result,
-            Err(p) => Poll::Ready(Err(Panic::from(p).into())),
-        }
     }
 }
 

--- a/src/actors.rs
+++ b/src/actors.rs
@@ -1000,12 +1000,20 @@ impl Stream for ActorStream {
     ) -> Poll<Option<Self::Item>> {
         trace!("Actor {} is being polled", self.context.aid.name_or_uuid());
         // If we have a pending future, that's what we poll.
-        if let Some(mut pending) = self.pending.take() {
+        if let Some(pending) = self.pending.as_mut() {
             // Poll, ensure we respect stopping condition.
-            pending
+            let poll = pending
                 .as_mut()
                 .poll(cx)
-                .map(|r| Some(self.overwrite_on_stop(r)))
+                .map(|r| Some(self.overwrite_on_stop(r)));
+
+            if let &Poll::Pending = &poll {
+                trace!("Actor {} is pending", self.context.aid.uuid());
+            } else {
+                drop(self.pending.take());
+            }
+
+            poll
         } else {
             // Are we stopped? If so, we should not have been polled, panic. This is only acceptable
             // because it means a bug in the Executor or Reactor.
@@ -1043,7 +1051,13 @@ impl Stream for ActorStream {
                     //
                     // While this is exhaustive, we're avoiding a catchall to in anticipation of
                     // future Secc errors we would *want* to handle.
-                    SeccErrors::Empty | SeccErrors::Full(_) => Poll::Ready(None),
+                    SeccErrors::Empty | SeccErrors::Full(_) => {
+                        trace!(
+                            "Actor `{}` has no more messages, return to sleep",
+                            self.context.aid.name_or_uuid()
+                        );
+                        Poll::Ready(None)
+                    }
                 },
             }
         }


### PR DESCRIPTION
Fixes #121.

Additionally, fixes an issue where pending handlers were dropped after a single attempt to poll.