### PR TITLE
Implement AidPool's: A Simple Mechanism for Actor Pools

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,10 @@ exclude = [
     "/.travis.yml",
 ]
 
+[features]
+default = []
+actor-pool = ["rand", "rand_xoshiro"]
+
 [badges]
 travis-ci = { repository = "rsimmonsjr/axiom" }
 is-it-maintained-issue-resolution = { repository = "rsimmonsjr/axiom" }
@@ -56,4 +60,6 @@ once_cell = "^1.0.2"
 secc = "^0.0.10"
 serde = { version = "^1.0.97", features = ["derive", "rc"] }
 uuid = { version = "^0.7.4", features = ["serde", "v4"]}
+rand = { version =  "0.7.3", optional = true }
+rand_xoshiro = { version = "0.4.0", optional = true }
 

--- a/src/actors.rs
+++ b/src/actors.rs
@@ -10,6 +10,13 @@ use crate::message::ActorMessage;
 use crate::prelude::*;
 use futures::{FutureExt, Stream};
 use log::{debug, error, trace, warn};
+#[cfg(feature = "actor-pool")]
+use rand::{
+    distributions::{Distribution, Uniform},
+    SeedableRng,
+};
+#[cfg(feature = "actor-pool")]
+use rand_xoshiro::Xoshiro256Plus;
 use secc::*;
 use serde::de::Deserializer;
 use serde::ser::Serializer;
@@ -33,7 +40,7 @@ use uuid::Uuid;
 #[derive(Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub enum Status {
     /// The message was processed and can be removed from the channel. Note that this doesn't
-    /// necessarily mean that anything was done with the message, just that it can be removed.  
+    /// necessarily mean that anything was done with the message, just that it can be removed.
     /// It is up to the actor to decide what, if anything, to do with the message.
     Done,
 
@@ -671,6 +678,56 @@ impl Aid {
     }
 }
 
+impl AidPool for Aid {
+    /// See [`Aid::send`]
+    #[inline]
+    fn send(&mut self, message: Message) -> Result<(), AidError> {
+        Aid::send(self, message)
+    }
+
+    /// See [`Aid::send_arc`]
+    #[inline]
+    fn send_arc<T>(&mut self, value: Arc<T>) -> Result<(), AidError>
+    where
+        T: 'static + ActorMessage,
+    {
+        Aid::send_arc(self, value)
+    }
+
+    /// See [`Aid::send_new`]
+    #[inline]
+    fn send_new<T>(&mut self, value: T) -> Result<(), AidError>
+    where
+        T: 'static + ActorMessage,
+    {
+        Aid::send_new(self, value)
+    }
+
+    /// See [`Aid::send_after`]
+    #[inline]
+    fn send_after(&mut self, message: Message, duration: Duration) -> Result<(), AidError> {
+        Aid::send_after(self, message, duration)
+    }
+
+    /// See [`Aid::send_arc_after`]
+    #[inline]
+    fn send_arc_after<T>(&mut self, value: Arc<T>, duration: Duration) -> Result<(), AidError>
+    where
+        T: 'static + ActorMessage,
+    {
+        Aid::send_arc_after(self, value, duration)
+    }
+
+    /// See [`Aid::send_new_after`]
+    #[inline]
+    fn send_new_after<T>(&mut self, value: T, duration: Duration) -> Result<(), AidError>
+    where
+        T: 'static + ActorMessage,
+    {
+        Aid::send_new_after(self, value, duration)
+    }
+}
+
 impl std::fmt::Debug for Aid {
     fn fmt(&self, formatter: &'_ mut std::fmt::Formatter) -> std::fmt::Result {
         write!(
@@ -697,6 +754,144 @@ impl Hash for Aid {
     fn hash<H: Hasher>(&self, state: &'_ mut H) {
         self.data.uuid.hash(state);
         self.data.system_uuid.hash(state);
+    }
+}
+
+/// Represents a pool of actor ids in which you don't care *which* actor recieves a
+/// message.
+///
+/// When a message is sent to a pool, only one actor in the pool will receive the message. Different
+/// [`AidPool`] implementations may have different ways of determining which actor to send a message
+/// to. The implmentation may send a message to a random actor or it may go in order, for example.
+///
+/// [`Aid`]'s also implement [`AidPool`] so an [`Aid`] can be used wherever a generic [`AidPool`] is
+/// expected.
+pub trait AidPool {
+    /// See [`Aid::send`]
+    fn send(&mut self, message: Message) -> Result<(), AidError>;
+    /// See [`Aid::send_arc`]
+    fn send_arc<T>(&mut self, value: Arc<T>) -> Result<(), AidError>
+    where
+        T: 'static + ActorMessage;
+    /// See [`Aid::send_new`]
+    fn send_new<T>(&mut self, value: T) -> Result<(), AidError>
+    where
+        T: 'static + ActorMessage;
+    /// See [`Aid::send_after`]
+    fn send_after(&mut self, message: Message, duration: Duration) -> Result<(), AidError>;
+    /// See [`Aid::send_arc_after`]
+    fn send_arc_after<T>(&mut self, value: Arc<T>, duration: Duration) -> Result<(), AidError>
+    where
+        T: 'static + ActorMessage;
+    /// See [`Aid::send_new_after`]
+    fn send_new_after<T>(&mut self, value: T, duration: Duration) -> Result<(), AidError>
+    where
+        T: 'static + ActorMessage;
+}
+
+/// An [`AidPool`] that sends messages to a random [`Aid`] in the pool.
+#[derive(Debug)]
+#[cfg(feature = "actor-pool")]
+pub struct RandomAidPool {
+    /// The list of contained [`Aid`]s
+    aids: Vec<Aid>,
+    /// The random number generator used to pick a random [`Aid`]
+    rng: Xoshiro256Plus,
+    /// The uniform range for generating random numbers withing the range of available
+    /// [`Aid`]s.
+    uniform: Uniform<usize>,
+}
+
+#[cfg(feature = "actor-pool")]
+impl RandomAidPool {
+    /// Create a [`RandomAidPool`] from a vector of [`Aid`]s
+    pub fn new(aids: Vec<Aid>) -> Self {
+        let len = aids.len();
+        RandomAidPool {
+            aids,
+            rng: Xoshiro256Plus::seed_from_u64(0),
+            uniform: Uniform::from(0..len),
+        }
+    }
+}
+
+#[cfg(feature = "actor-pool")]
+impl AidPool for RandomAidPool {
+    /// See [`Aid::send`]
+    #[inline]
+    fn send(&mut self, message: Message) -> Result<(), AidError> {
+        self.aids[self.uniform.sample(&mut self.rng)].send(message)
+    }
+
+    /// See [`Aid::send_arc`]
+    #[inline]
+    fn send_arc<T>(&mut self, value: Arc<T>) -> Result<(), AidError>
+    where
+        T: 'static + ActorMessage,
+    {
+        self.aids[self.uniform.sample(&mut self.rng)].send_arc(value)
+    }
+
+    /// See [`Aid::send_new`]
+    #[inline]
+    fn send_new<T>(&mut self, value: T) -> Result<(), AidError>
+    where
+        T: 'static + ActorMessage,
+    {
+        self.aids[self.uniform.sample(&mut self.rng)].send_new(value)
+    }
+
+    /// See [`Aid::send_after`]
+    #[inline]
+    fn send_after(&mut self, message: Message, duration: Duration) -> Result<(), AidError> {
+        self.aids[self.uniform.sample(&mut self.rng)].send_after(message, duration)
+    }
+
+    /// See [`Aid::send_arc_after`]
+    #[inline]
+    fn send_arc_after<T>(&mut self, value: Arc<T>, duration: Duration) -> Result<(), AidError>
+    where
+        T: 'static + ActorMessage,
+    {
+        self.aids[self.uniform.sample(&mut self.rng)].send_arc_after(value, duration)
+    }
+
+    /// See [`Aid::send_new_after`]
+    #[inline]
+    fn send_new_after<T>(&mut self, value: T, duration: Duration) -> Result<(), AidError>
+    where
+        T: 'static + ActorMessage,
+    {
+        self.aids[self.uniform.sample(&mut self.rng)].send_new_after(value, duration)
+    }
+}
+
+#[cfg(feature = "actor-pool")]
+impl From<Vec<Aid>> for RandomAidPool {
+    fn from(aids: Vec<Aid>) -> Self {
+        Self::new(aids)
+    }
+}
+
+#[cfg(feature = "actor-pool")]
+impl Into<Vec<Aid>> for RandomAidPool {
+    fn into(self) -> Vec<Aid> {
+        self.aids
+    }
+}
+
+#[cfg(feature = "actor-pool")]
+impl Clone for RandomAidPool {
+    fn clone(&self) -> Self {
+        // Jump the rng to prevent colliding random numbers from this cloned pool
+        let mut new_rng = self.rng.clone();
+        new_rng.jump();
+
+        RandomAidPool {
+            aids: self.aids.clone(),
+            rng: new_rng,
+            uniform: self.uniform,
+        }
     }
 }
 
@@ -760,6 +955,7 @@ impl<F> Handler for F where F: (FnMut(Context, Message) -> HandlerFuture) + Send
 /// A builder that can be used to create and spawn an actor. To get a builder, the user would ask
 /// the actor system to create one using `system.spawn()` and then to spawn the actor by means of
 /// the the `with` method on the builder. See [`ActorSystem::actor`] for more information.
+#[derive(Clone)]
 pub struct ActorBuilder {
     /// The System that the actor builder was created on.
     pub(crate) system: ActorSystem,
@@ -799,6 +995,63 @@ impl ActorBuilder {
     pub fn channel_size(mut self, size: u16) -> Self {
         assert!(size > 0);
         self.channel_size = Some(size);
+        self
+    }
+}
+
+/// A builder than can be used to spawn an actor pool.Uniform
+///
+/// See [`ActorBuilder`].
+#[cfg(feature = "actor-pool")]
+pub struct ActorPoolBuilder {
+    /// The actor builder used to build the actors in the pool
+    builder: ActorBuilder,
+    /// The number of actors to build in the pool
+    count: usize,
+}
+
+#[cfg(feature = "actor-pool")]
+impl ActorPoolBuilder {
+    /// Create a new [`ActorPoolBuilder`] from a normal [`ActorBuilder`].
+    pub fn new(builder: ActorBuilder, count: usize) -> Self {
+        ActorPoolBuilder { builder, count }
+    }
+
+    /// See [`ActorBuilder::with`]
+    pub fn with<F, S, R, P>(self, state: S, processor: F) -> Result<P, SystemError>
+    where
+        S: Clone + Send + Sync + 'static,
+        R: Future<Output = ActorResult<S>> + Send + 'static,
+        F: Processor<S, R> + Clone + 'static,
+        P: AidPool + From<Vec<Aid>>,
+    {
+        let mut aids = Vec::with_capacity(self.count);
+        for i in 0..self.count {
+            // Clone the builder
+            let mut b = self.builder.clone();
+            // Add index as name suffix
+            b.name = b.name.map(|name| format!("{}_{}", name, i));
+            // Add aid to list
+            aids.push(b.with(state.clone(), processor.clone())?)
+        }
+
+        // Return an `AidPool` from the list of `Aid`s
+        Ok(P::from(aids))
+    }
+
+    /// Set the base name for the actors created in this pool.
+    ///
+    /// The name will be suffixed with "_{index}" to make the name unique. For example, if you
+    /// set the name to "worker" and there were 3 actors in the pool, you would end up with the
+    /// actors with the names: "worker_0", "worker_1", "worker_2".
+    pub fn name(mut self, name: impl Into<String>) -> Self {
+        self.builder = self.builder.name(name);
+        self
+    }
+
+    /// See [`ActorBuilder::channel_size`]
+    pub fn channel_size(mut self, size: u16) -> Self {
+        self.builder = self.builder.channel_size(size);
         self
     }
 }

--- a/src/actors.rs
+++ b/src/actors.rs
@@ -789,6 +789,14 @@ pub trait AidPool {
         T: 'static + ActorMessage;
 }
 
+/// A helper trait that is simply an AidPool that can be passed between actors, i.e. it is
+/// `Sync + Send + Clone + 'static`. This is useful when you want to make a function generic over
+/// [`AidPool`] but you need to be able to give the poool to actor.
+pub trait SyncAidPool: AidPool + Sync + Send + Clone + 'static {}
+
+// Auto implement SyncAidPool for complying [`AidPool`]s
+impl<T: AidPool + Sync + Send + Clone + 'static> SyncAidPool for T {}
+
 /// An [`AidPool`] that sends messages to a random [`Aid`] in the pool.
 #[derive(Debug)]
 #[cfg(feature = "actor-pool")]

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -466,12 +466,10 @@ mod tests {
         let system = ActorSystem::create(ActorSystemConfig::default().thread_pool_size(2));
         let _aid = system
             .spawn()
-            .with((), |_: (), c: Context, _: Message| {
-                async move {
-                    let r = PendingNTimes::new(1, 50).await;
-                    c.system.trigger_shutdown();
-                    r
-                }
+            .with((), |_: (), c: Context, _: Message| async move {
+                let r = PendingNTimes::new(1, 50).await;
+                c.system.trigger_shutdown();
+                r
             })
             .unwrap();
         assert_ne!(
@@ -501,14 +499,12 @@ mod tests {
         let system = ActorSystem::create(ActorSystemConfig::default().thread_pool_size(1));
         let aid = system
             .spawn()
-            .with((), |_: (), _: Context, msg: Message| {
-                async move {
-                    if let Some(_) = msg.content_as::<SystemMsg>() {
-                        return Ok(Status::done(()));
-                    }
-
-                    PendingNTimes::new(1, 25).await
+            .with((), |_: (), _: Context, msg: Message| async move {
+                if let Some(_) = msg.content_as::<SystemMsg>() {
+                    return Ok(Status::done(()));
                 }
+
+                PendingNTimes::new(1, 25).await
             })
             .unwrap();
         await_received(&aid, 1, 5).expect("Actor took too long to process Start");

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -252,7 +252,7 @@ impl AxiomReactor {
             match task.poll(&w.waker) {
                 Poll::Ready(result) => {
                     // Ready(None) indicates an empty message queue. Time to sleep.
-                    if let None = result {
+                    if result.is_none() {
                         self.executor.return_task(task, self);
                         break;
                     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -375,8 +375,8 @@ mod tests {
         // but when that bug goes away this will be even simpler.
         let aid = system
             .spawn()
-            .with((), |_: (), _: Context, _: Message| {
-                async { Ok(Status::done(())) }
+            .with((), |_: (), _: Context, _: Message| async {
+                Ok(Status::done(()))
             })
             .unwrap();
 

--- a/src/message.rs
+++ b/src/message.rs
@@ -150,7 +150,7 @@ impl Message {
         Message {
             data: Arc::new(MessageData {
                 type_id_hash: Message::hash_type_id::<T>(),
-                content: RwLock::new(MessageContent::Local(value.clone())),
+                content: RwLock::new(MessageContent::Local(value)),
             }),
         }
     }
@@ -213,7 +213,7 @@ impl Message {
                                     let new_value: Arc<T> = Arc::new(concrete);
                                     *write_guard = MessageContent::Local(new_value.clone());
                                     drop(write_guard);
-                                    Some(new_value.clone())
+                                    Some(new_value)
                                 }
                                 Err(err) => {
                                     // The only reason this should happen is if the type id hash

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,6 +1,10 @@
 pub use crate::actors::Aid;
 pub use crate::actors::AidError;
+#[cfg(feature = "actor-pool")]
+pub use crate::actors::AidPool;
 pub use crate::actors::Context;
+#[cfg(feature = "actor-pool")]
+pub use crate::actors::RandomAidPool;
 pub use crate::actors::Status;
 pub use crate::executor::ShutdownResult;
 pub use crate::message::Message;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -6,6 +6,8 @@ pub use crate::actors::Context;
 #[cfg(feature = "actor-pool")]
 pub use crate::actors::RandomAidPool;
 pub use crate::actors::Status;
+#[cfg(feature = "actor-pool")]
+pub use crate::actors::SyncAidPool;
 pub use crate::executor::ShutdownResult;
 pub use crate::message::Message;
 pub use crate::system::ActorSystem;

--- a/src/system/system_actor.rs
+++ b/src/system/system_actor.rs
@@ -33,7 +33,7 @@ impl SystemActor {
             }
             Ok(Status::done(self))
         // Do nothing special if we get a SystemMsg.
-        } else if let Some(_) = message.content_as::<SystemMsg>() {
+        } else if message.content_as::<SystemMsg>().is_some() {
             Ok(Status::done(self))
         // Log an error if we get an unexpected message kind, but continue processing as normal.
         } else {


### PR DESCRIPTION
I'm not 100% sure that this is the right idea, but I was looking for a way to send messages to a pool of identical actors in a manner that was similar to a thread pool. I'd love to get feedback on whether or not this is a good approach to this.

My use-case was that I had an actor that would send HTTP notifications when it received messages, but if there were a lot of notifications that needed to be sent at the same time, I didn't want it to wait for that actor to finish sending a notification before it could send another one. Using an actor pool was my attempt at a solution. You can use `spawn_pool` to tell the system to spawn a number of identical actors and return an `AidPool` ( or rather something that implements the `AidPool` trait, currently only implemented by `RandomAidPool` ). `AidPool` has `send()`, `send_new()`, etc. functions and the `RandomAidPool` implementation will send messages to a random `Aid` in the pool. A better implementation might send a message to any non-busy actor, but I didn't know how or if there was any way to tell whether an actor was busy or not.

The PR comes with a test for `spawn_pool` and some documentation for the new types/functions.

Right now the test fails randomly from a send timeout, and I don't know why that is. I could maybe use some help understanding what causes that. I seems like it might be related to a similar random test failure ( caused by a timeout ) in that is occurring in the `executor::tests::test_actor_awake_phases` test on master right now.

This pulls in the `rand` and `rand_xoshiro` crates for the `RandomAidPool` implementation and I wasn't sure if we wanted that by default so I put it behind the `actor-pool` feature. If you would rather not have the feature, it would be easy just to take out the feature gates.

I'm not 100% sure that the choice of the Xoshiro random generator was the right one, but it is one of the fastest random generators according to the table in the Rust random book so that is why I went with it. It also has the nifty `jump()` feature that can be used to make sure that a clone of the random generator won't yield overlapping values for a large number of samples, which is useful when cloning the `AidPool` to make sure that the clones of the pool don't end up doubling up on sending messages to the same actors.