### PR TITLE
Shrink unsafe block

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -29,8 +29,8 @@ pub trait ActorMessage: Send + Sync + Any {
 impl dyn ActorMessage {
     fn downcast<T: ActorMessage>(self: Arc<Self>) -> Option<Arc<T>> {
         if TypeId::of::<T>() == (*self).type_id() {
+            let ptr = Arc::into_raw(self) as *const T;
             unsafe {
-                let ptr = Arc::into_raw(self) as *const T;
                 Some(Arc::from_raw(ptr))
             }
         } else {


### PR DESCRIPTION
In this function you use the unsafe keyword for some safe expressions. However, I found that only 1 function is real unsafe operations (see the list below). 

We need to mark unsafe operations more precisely using unsafe keyword. Keeping unsafe blocks small can bring many benefits. For example, when mistakes happen, we can locate any errors related to memory safety  within an unsafe block. This is the balance between Safe and Unsafe Rust. The separation is designed to make using Safe Rust as ergonomic as possible, but requires extra effort and care when writing Unsafe Rust. 
**Real unsafe operation list:**
1. the from_raw() function(unsafe function)

@FenrirWolf
Hope this PR can help you.
Best regards.
**References**
https://doc.rust-lang.org/nomicon/safe-unsafe-meaning.html 
https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html 